### PR TITLE
fix(card-farming): card farming close button stops auto idle task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,6 @@ next-env.d.ts
 src-tauri/target
 src-tauri/libs
 src-tauri/gen
+.window-state.json
 
 *.ps1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+<!-- 2.1.10 -->
+
+### Changes in v2.1.10
+
+- Fixed an issue where the Close button in Card Farming screen would stop the scheduled Automatic Idler task (#770)
+
 <!-- 2.1.9 -->
 
 ### Changes in v2.1.9

--- a/src/components/automation/CardFarming.tsx
+++ b/src/components/automation/CardFarming.tsx
@@ -30,6 +30,7 @@ export default function CardFarming({ activePage }: { activePage: ActivePageType
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useCardFarming(
       setIsComplete,
+      setIsCardFarming,
       setTotalDropsRemaining,
       setGamesWithDrops,
       startAchievementUnlocker,

--- a/src/hooks/automation/useCardFarming.ts
+++ b/src/hooks/automation/useCardFarming.ts
@@ -40,6 +40,7 @@ interface CycleStep {
 
 export const useCardFarming = async (
   setIsComplete: Dispatch<SetStateAction<boolean>>,
+  setIsCardFarming: Dispatch<SetStateAction<boolean>>,
   setTotalDropsRemaining: Dispatch<SetStateAction<number>>,
   setGamesWithDrops: Dispatch<SetStateAction<Set<GameWithDrops>>>,
   startAchievementUnlocker: () => Promise<void>,
@@ -75,11 +76,15 @@ export const useCardFarming = async (
 
         if (nextTask.shouldStartNextTask) {
           if (nextTask.task && nextTask.task === 'achievementUnlocker') {
+            await stopFarmIdle(gamesSet)
+            setIsCardFarming(false)
             await startAchievementUnlocker()
             logEvent('[Card Farming] No drops remaining - moving to next task: ' + nextTask.task)
           }
 
           if (nextTask.task && nextTask.task === 'autoIdle') {
+            await stopFarmIdle(gamesSet)
+            setIsCardFarming(false)
             await startAutoIdleGames()
             logEvent('[Card Farming] No drops remaining - moving to next task: ' + nextTask.task)
           }


### PR DESCRIPTION
fixes #770 