### PR TITLE
feat(settings): add global max idle time option to game settings

### DIFF
--- a/docs/app/docs/settings/game-settings/page.mdx
+++ b/docs/app/docs/settings/game-settings/page.mdx
@@ -4,6 +4,12 @@ description: "View the settings for individual games, allowing for customized co
 
 # Game Settings
 
+#### Global Max Idle Time
+
+Set the maximum amount of time (in minutes) all games should be idled for. This setting takes precedence over individual `Max Idle Time` settings for each game
+
+This only affects games that are idled by [Playtime Booster](/docs/features/playtime-booster) and [Auto Idler](/docs/features/auto-idler), and does not affect games idled by [Card Farming](/docs/features/card-farming) or [Achievement Unlocker](/docs/features/achievement-unlocker)
+
 #### Max Idle Time
 
 Set the maximum amount of time (in minutes) this game should be idled for. SGI will stop idling this game when the time limit is reached

--- a/notifications.json
+++ b/notifications.json
@@ -1,5 +1,12 @@
 [
   {
+    "id": "28",
+    "title": "New Feature: Global Max Idle Time",
+    "message": "Click here to learn more about the new global max idle time feature released in 2.4.0",
+    "url": "http://steamgameidler.com/docs/settings/game-settings#global-max-idle-time",
+    "timestamp": "1763547660"
+  },
+  {
     "id": "27",
     "title": "New Feature: Per-Achievement Unlock Delay",
     "message": "Click here to learn more about the new per-achievement unlock delay feature released in 2.4.0",

--- a/src/components/settings/GameSettings.tsx
+++ b/src/components/settings/GameSettings.tsx
@@ -71,8 +71,10 @@ export default function GameSettings(): ReactElement {
   const [selectedGame, setSelectedGame] = useState<Game | null>(null)
 
   const {
+    globalMaxIdleTime,
     maxIdleTime,
     maxCardDrops,
+    handleGlobalMaxIdleTimeChange,
     maxAchievementUnlocks,
     handleMaxIdleTimeChange,
     handleMaxCardDropsChange,
@@ -141,6 +143,40 @@ export default function GameSettings(): ReactElement {
           >
             {Row}
           </List>
+        </div>
+
+        <Divider className='bg-border/70 my-4' />
+
+        <div className='flex justify-between items-center'>
+          <div className='flex flex-col gap-2 w-1/2'>
+            <p className='text-sm text-content font-bold'>{t('gameSettings.globalMaxIdle')}</p>
+            <p className='text-xs text-altwhite'>
+              <Trans i18nKey='gameSettings.globalMaxIdleSub' />
+            </p>
+          </div>
+          <NumberInput
+            size='sm'
+            value={globalMaxIdleTime}
+            step={1}
+            minValue={0}
+            maxValue={99999}
+            aria-label='max idle time'
+            className='w-[90px]'
+            classNames={{
+              inputWrapper: cn(
+                'bg-input data-[hover=true]:!bg-inputhover border-none',
+                'group-data-[focus-visible=true]:ring-transparent',
+                'group-data-[focus-visible=true]:ring-offset-transparent',
+                'group-data-[focus-within=true]:!bg-inputhover',
+                'border group-data-[invalid=true]:border-red-500!',
+                'border group-data-[invalid=true]:bg-red-500/10!',
+                !selectedGame && 'opacity-50',
+              ),
+              input: ['text-sm !text-content'],
+              stepperButton: ['!text-content', 'text-sm'],
+            }}
+            onValueChange={handleGlobalMaxIdleTimeChange}
+          />
         </div>
 
         <Divider className='bg-border/70 my-4' />

--- a/src/hooks/automation/useAchievementUnlocker.ts
+++ b/src/hooks/automation/useAchievementUnlocker.ts
@@ -358,7 +358,11 @@ const getMaxAchievementUnlocks = async (steamId: string | undefined, appId: numb
       steamId,
     })
     const gameSettings = response.settings.gameSettings || {}
-    return gameSettings[appId]?.maxAchievementUnlocks || null
+    const perGameSetting = gameSettings[appId]
+    if (typeof perGameSetting === 'object' && perGameSetting !== null && !Array.isArray(perGameSetting)) {
+      return perGameSetting.maxAchievementUnlocks || null
+    }
+    return null
   } catch (error) {
     handleError('getMaxAchievementUnlocks', error)
     return null

--- a/src/hooks/automation/useCardFarming.ts
+++ b/src/hooks/automation/useCardFarming.ts
@@ -173,8 +173,11 @@ const processGamesWithDrops = (
         const gameName = gameData.name
         const remaining = isGameWithDrops ? gameData.remaining : 0
 
-        const gameSetting = gameSettings[gameId] || {}
-        const maxCardDrops = gameSetting?.maxCardDrops || remaining
+        const gameSetting = gameSettings[gameId]
+        let maxCardDrops = remaining
+        if (typeof gameSetting === 'object' && gameSetting !== null && !Array.isArray(gameSetting)) {
+          maxCardDrops = gameSetting.maxCardDrops ?? remaining
+        }
         const dropsToCount = Math.min(remaining, maxCardDrops)
 
         gamesSet.add({
@@ -216,8 +219,11 @@ const processIndividualGames = async (
       ])
 
       if (dropsRemaining > 0) {
-        const gameSetting = gameSettings[gameData.appid] || {}
-        const maxCardDrops = gameSetting?.maxCardDrops || dropsRemaining
+        const gameSetting = gameSettings[gameData.appid]
+        let maxCardDrops = dropsRemaining
+        if (typeof gameSetting === 'object' && gameSetting !== null && !Array.isArray(gameSetting)) {
+          maxCardDrops = gameSetting.maxCardDrops ?? dropsRemaining
+        }
         const dropsToCount = Math.min(Number(dropsRemaining), Number(maxCardDrops))
 
         gamesSet.add({

--- a/src/i18n/locales/en-US/translation.json
+++ b/src/i18n/locales/en-US/translation.json
@@ -95,6 +95,8 @@
   "cardMenu.idle": "Start idling",
   "cardMenu.achievements": "View achievements",
   "cardMenu.store": "View store page",
+  "gameSettings.globalMaxIdle": "Global Max Idle Time",
+  "gameSettings.globalMaxIdleSub": "The maximum amount of time (in minutes) all games should be idled for before stopping (overrides individual game settings)",
   "gameSettings.idle": "Max Idle Time",
   "gameSettings.idleSub": "The maximum amount of time (in minutes) this game should be idled for before stopping",
   "gameSettings.drops": "Max Card Drops",

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -39,7 +39,8 @@ export interface GameSpecificSettings {
 }
 
 export interface GameSettings {
-  [appId: string]: GameSpecificSettings
+  globalMaxIdleTime?: number
+  [appId: string]: GameSpecificSettings | number | undefined
 }
 
 export interface GeneralSettings {

--- a/src/utils/idle.ts
+++ b/src/utils/idle.ts
@@ -23,7 +23,17 @@ export async function startIdle(appId: number, appName: string, manual: boolean 
     })
 
     const gameSettings = settingsResponse.settings.gameSettings || {}
-    const maxIdleTime = gameSettings[appId]?.maxIdleTime || 0
+    let maxIdleTime = 0
+    // Check for globalMaxIdleTime first
+    const globalMaxIdleTime = typeof gameSettings.globalMaxIdleTime === 'number' ? gameSettings.globalMaxIdleTime : 0
+    if (globalMaxIdleTime > 0) {
+      maxIdleTime = globalMaxIdleTime
+    } else {
+      const perGameSetting = gameSettings[appId]
+      if (typeof perGameSetting === 'object' && perGameSetting !== null && !Array.isArray(perGameSetting)) {
+        maxIdleTime = perGameSetting.maxIdleTime || 0
+      }
+    }
 
     // Make sure the game is not already being idled
     const response = await invoke<InvokeRunningProcess>('get_running_processes')


### PR DESCRIPTION
### Description
Set the maximum amount of time (in minutes) all games should be idled for. This setting takes precedence over individual `Max Idle Time` settings for each game