### PR TITLE
refactor(settings): increase trading card min sell delay to prevent r…

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -60,7 +60,7 @@ fn get_default_settings() -> Value {
                 "min": 0.01,
                 "max": 1.10
             },
-            "sellDelay": 3
+            "sellDelay": 5
         },
     })
 }

--- a/src/components/contexts/UserContext.tsx
+++ b/src/components/contexts/UserContext.tsx
@@ -68,7 +68,7 @@ export const UserProvider = ({ children }: { children: ReactNode }): ReactElemen
         min: 0.01,
         max: 1.1,
       },
-      sellDelay: 3,
+      sellDelay: 5,
     },
   })
 

--- a/src/components/settings/TradingCardManagerSettings.tsx
+++ b/src/components/settings/TradingCardManagerSettings.tsx
@@ -18,13 +18,13 @@ export default function TradingCardManagerSettings(): ReactElement {
   const [priceAdjustment, setPriceAdjustment] = useState<number>(0.0)
   const [sellLimitMin, setSellLimitMin] = useState<number>(0.01)
   const [sellLimitMax, setSellLimitMax] = useState<number>(1.1)
-  const [sellDelay, setSellDelay] = useState<number>(3)
+  const [sellDelay, setSellDelay] = useState<number>(5)
 
   useEffect(() => {
     setPriceAdjustment(userSettings?.tradingCards?.priceAdjustment || 0.0)
     setSellLimitMin(userSettings?.tradingCards?.sellLimit?.min || 0.01)
     setSellLimitMax(userSettings?.tradingCards?.sellLimit?.max || 1.1)
-    setSellDelay(userSettings?.tradingCards?.sellDelay || 3)
+    setSellDelay(userSettings?.tradingCards?.sellDelay || 5)
   }, [
     userSettings?.tradingCards?.priceAdjustment,
     userSettings?.tradingCards?.sellLimit,
@@ -301,8 +301,8 @@ export default function TradingCardManagerSettings(): ReactElement {
             size='sm'
             value={sellDelay}
             step={1}
-            minValue={3}
-            maxValue={15}
+            minValue={5}
+            maxValue={30}
             aria-label='sell delay value'
             className='w-[90px]'
             classNames={{

--- a/src/hooks/trading-cards/useTradingCardsList.ts
+++ b/src/hooks/trading-cards/useTradingCardsList.ts
@@ -358,7 +358,7 @@ export default function useTradingCardsList(): UseTradingCardsList {
   const handleSellSelectedCards = async (): Promise<void> => {
     try {
       const credentials = userSettings.cardFarming.credentials
-      const sellDelay = userSettings?.tradingCards?.sellDelay || 3
+      const sellDelay = userSettings?.tradingCards?.sellDelay || 5
 
       if (!credentials?.sid || !credentials?.sls) return showMissingCredentialsToast()
 
@@ -471,7 +471,7 @@ export default function useTradingCardsList(): UseTradingCardsList {
       showPrimaryToast(t('toast.tradingCards.processing'))
 
       const priceAdjustment = userSettings?.tradingCards?.priceAdjustment || 0.0
-      const sellDelay = userSettings?.tradingCards?.sellDelay || 3
+      const sellDelay = userSettings?.tradingCards?.sellDelay || 5
       const successfulCards = []
       const failedCards = []
       const skippedCards = []
@@ -496,7 +496,9 @@ export default function useTradingCardsList(): UseTradingCardsList {
           const priceResult = await fetchCardPrices(card.market_hash_name)
 
           if (!priceResult.success) {
-            logEvent(`[Error] Failed to fetch price for card ${card.assetid} (${card.market_hash_name}) - skipping`)
+            logEvent(
+              `[Error] Failed to fetch price for card ${card.assetid} (${card.market_hash_name}) (Increasing the 'sell delay' in 'settings > trading card manager' can help prevent this issue') - skipping`,
+            )
             continue
           }
 


### PR DESCRIPTION
### Description
To prevent rate limiting on the endpoint for listing trading cards, I have increased the minimum `sell delay` from `3` to `5`.

I have also added a more descriptive error message when failing to fetch card prices, which lets the user know to increase the `sell delay` setting, as this is usually when the rate limit occurs and is the likely culprit for this error.

### Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->