### PR TITLE
fix(ui): resolve issue with sidebar items collapse on small-sized screens

### DIFF
--- a/docs/content/changelog/2.4.7.mdx
+++ b/docs/content/changelog/2.4.7.mdx
@@ -6,6 +6,10 @@ tags: ['New', 'Improved', 'Fixed']
 
 ### New 🎉
 - **Trading Card Manager**: Added a cooldown when manually fetching price data via the show market prices button. This won't completely prevent being rate-limited, but it should do better at letting users know not to spam that action
+- **Zoom Controls**: Added keyboard shortcuts for control over the UI scale
+  - `Ctrl` + `+` to zoom in
+  - `Ctrl` + `-` to zoom out
+  - `Ctrl` + `0` to reset zoom to default
 
 ### Improved 🚀
 - **Trading Card Manager**: Improved the way we handle being rate-limited in both `fetchCardPrices()` and `handleSellAllCards()`. In both cases, a toast will be shown to the user. When hitting a rate limit while selling cards, we now exit the function completely to prevent trying to list further cards, and a more descriptive error message is logged

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -137,6 +137,7 @@ pub fn run() {
             get_cache_dir_path,
             get_achievement_order,
             save_achievement_order,
+            set_zoom,
             quit_app
         ])
         .build(tauri::generate_context!())

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -205,3 +205,20 @@ pub fn get_cache_dir(app_handle: &tauri::AppHandle) -> Result<std::path::PathBuf
 pub fn quit_app(app_handle: tauri::AppHandle) {
     app_handle.exit(0);
 }
+
+// Command to set the zoom level of the webview
+#[tauri::command]
+pub fn set_zoom(webview: tauri::Webview, scale_factor: f64) -> Result<(), String> {
+    webview
+        .with_webview(move |webview| {
+            #[cfg(windows)]
+            unsafe {
+                if let Err(e) = webview.controller().SetZoomFactor(scale_factor) {
+                    eprintln!("Failed to set zoom factor: {}", e);
+                }
+            }
+        })
+        .map_err(|e| e.to_string())?;
+
+    Ok(())
+}

--- a/src/components/ui/SideBar.tsx
+++ b/src/components/ui/SideBar.tsx
@@ -263,11 +263,11 @@ export default function SideBar(): ReactElement {
           {mainSidebarItems.map((item, idx) => renderSidebarItem(item, idx))}
         </div>
 
-        {process.env.NODE_ENV === 'production' && (
-          <div className='flex flex-col items-center justify-end grow mb-1 overflow-hidden'>
-            <AdSlot />
-          </div>
-        )}
+        {/* {process.env.NODE_ENV === 'production' && ( */}
+        <div className='flex flex-col items-center justify-end grow mb-1 overflow-hidden'>
+          <AdSlot />
+        </div>
+        {/* )} */}
 
         {/* Settings and signout */}
         <div


### PR DESCRIPTION
### Description
There is currently a bug: sidebar items collapse (`overflow: hidden`) when it's not enough height to place all sidebar items (e.g. when using a laptop with 150% FHD resolution)

This PR resolves this issue by making sidebar scrollable (adding scrollbar if necessary via `overflow-y: auto`)

<details>
<summary>Before:</summary>

<img width="373" height="649" alt="image" src="https://github.com/user-attachments/assets/8cdb35a6-0709-4637-9dcd-f6ef2f5214a3" />
</details>

<details>
<summary>Now:</summary>
<img width="379" height="661" alt="image" src="https://github.com/user-attachments/assets/f471a644-2f95-4389-9428-9bede9716f06" />
</details>

