### PR TITLE
perf(tauri): move frequent heavy operations to rust backend

### DIFF
--- a/docs/content/changelog/2.5.3.mdx
+++ b/docs/content/changelog/2.5.3.mdx
@@ -8,8 +8,10 @@ tags: ['New', 'Improved', 'Fixed']
 - **New Themes**: Added two new **PRO** themes, "**Pink**" and "**Gold**", available in the **Customization** settings tab
 
 ### Improved 🚀
+- **Performance**: Moved frequent heavy operations to the Rust backend. This has significantly improved memory usage and overall application responsiveness, especially on lower-end systems
 - Tweaked the "**Default**" theme for better consistency across components
 - Other minor visual improvements across all themes for a more polished look
 
 ### Fixed 🐛
+- Fixed an issue with the game card idle timers which could cause a slight memory leak over time, especially when idling many games simultaneously
 - Fixed an issue where zoom controls (`Ctrl` + '+' / '-') were not working if another element had focus

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -137,6 +137,8 @@ pub fn run() {
             get_cache_dir_path,
             get_achievement_order,
             save_achievement_order,
+            start_steam_status_monitor,
+            start_processes_monitor,
             set_zoom,
             quit_app
         ])

--- a/src/components/ui/CustomModal.tsx
+++ b/src/components/ui/CustomModal.tsx
@@ -5,7 +5,6 @@ import { cn, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader } from '@h
 
 interface CustomModalProps {
   isOpen?: boolean
-  onOpen?: () => void
   onOpenChange?: () => void
   className?: string
   classNames?: ModalProps['classNames']
@@ -17,7 +16,6 @@ interface CustomModalProps {
 
 export default function CustomModal({
   isOpen,
-  onOpen,
   onOpenChange,
   className,
   classNames,

--- a/src/components/ui/IdleTimer.tsx
+++ b/src/components/ui/IdleTimer.tsx
@@ -28,17 +28,12 @@ export default function IdleTimer({ startTime }: { startTime: number }): ReactEl
 
   const [, forceUpdate] = useState<Record<string, never>>({})
 
-  // Update time every frame
   useEffect(() => {
-    let frameId: number
-
-    const updateTimer = (): void => {
+    const intervalId = setInterval(() => {
       forceUpdate({})
-      frameId = requestAnimationFrame(updateTimer)
-    }
+    }, 1000)
 
-    frameId = requestAnimationFrame(updateTimer)
-    return () => cancelAnimationFrame(frameId)
+    return () => clearInterval(intervalId)
   }, [])
 
   // Calculate time directly in render

--- a/src/components/ui/SteamWarning.tsx
+++ b/src/components/ui/SteamWarning.tsx
@@ -19,12 +19,9 @@ export default function SteamWarning(): ReactElement {
 
   useEffect(() => {
     const shouldShowWarning = async (): Promise<void> => {
-      const devAccounts = ['76561198158912649', '76561198999797359']
       const isDev = await invoke('is_dev')
 
-      const isUserDev = devAccounts.includes(userSummary?.steamId ?? '')
-
-      if (showSteamWarning && !isDev && !isUserDev) {
+      if (showSteamWarning && !isDev) {
         onOpen()
       }
     }


### PR DESCRIPTION
### Description
Frequent checks, such as detecting whether the Steam client is running and monitoring idling game processes, that were previously handled in the webview are now done in the Rust backend, reducing overall memory usage.

### Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->