### PR TITLE
refactor(utils): limit max concurrent idling processes to 32

### DIFF
--- a/docs/content/changelog/2.5.5.mdx
+++ b/docs/content/changelog/2.5.5.mdx
@@ -5,4 +5,5 @@ tags: ['Improved']
 ---
 
 ### Improved 🚀
+- Added a check when starting to idle a game to prevent exceeding the maximum of 32 concurrent idling games. This isn't necessarily a bad thing if you exceed the limit, those games just wont be recognized by the Steam client, but it helps avoid wasted resources and potential issues
 - Fixed an issue where the changelog modal would sometimes load the incorrect version after an update

--- a/src/utils/idle.ts
+++ b/src/utils/idle.ts
@@ -40,8 +40,18 @@ export async function startIdle(appId: number, appName: string, manual: boolean 
     const processes = response?.processes
     const runningIdlers = processes.map(p => p.appid)
 
+    if (processes.length === 3) {
+      // We already show a warning toast if startIdle returns false in most cases, so just log here
+      logEvent(
+        `[Error] [Idle] Maximum number of idling processes (32) reached when attempting to idle ${appName} (${appId})`,
+      )
+      return false
+    }
+
     if (runningIdlers.includes(appId)) {
+      // This is unlikely to happen but worth handling just in case
       showWarningToast(t('toast.startIdle.alreadyIdling', { appName, appId }))
+      logEvent(`[Error] [Idle] Attempted to idle already idling game ${appName} (${appId})`)
       return false
     }
 


### PR DESCRIPTION
### Description
<!-- Briefly describe the changes in this PR -->

### Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->