### PR TITLE
fix(chat): user badges on wrong side of username

### DIFF
--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -201,7 +201,7 @@ function ChatMessage({
                   style={{
                     fontWeight: userRoles[msg.user_id] ? 'bold' : 'normal',
                   }}
-                  className={cn('mr-1 text-xs text-[#3f3f3f]', getRoleStyles(currentRole))}
+                  className={cn('mr-1 text-xs text-[#3f3f3f] inline-flex items-center', getRoleStyles(currentRole))}
                 >
                   {msg.username}
                   <ChatRoleBadge role={currentRole} />


### PR DESCRIPTION
### Description
<!-- Briefly describe the changes in this PR -->

### Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->