### PR TITLE
ignore local build script files in versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ public/robots.txt
 
 # Keys
 *.pem
+
+# Scripts
+*.ps1


### PR DESCRIPTION
Need to ignore `.ps1` files as my local contains a few test/build scripts that don't need to be included in versioning