### PR TITLE
fix(achievement-unlocker): next unlock timer not being shown

### DIFF
--- a/docs/content/changelog/4.0.2.mdx
+++ b/docs/content/changelog/4.0.2.mdx
@@ -1,0 +1,9 @@
+---
+title: 4.0.2
+date: 2026-02-09
+tags: ['Fixed']
+---
+
+### Fixed 🐛
+- Fixed an issue in "**Achievement Unlocker**" where the countdown timer to the next achievement unlock was not being displayed
+- Other minor miscellaneous fixes

--- a/src/features/achievement-unlocker/components/AchievementUnlocker.tsx
+++ b/src/features/achievement-unlocker/components/AchievementUnlocker.tsx
@@ -186,10 +186,10 @@ export const AchievementUnlocker = ({ activePage }: { activePage: ActivePageType
                   <Trans
                     i18nKey='automation.achievementUnlocker.delay'
                     values={{ timer: countdownTimer }}
-                  >
-                    Next unlock in{' '}
-                    <span className='font-bold text-sm text-dynamic'>{countdownTimer}</span>
-                  </Trans>
+                    components={{
+                      1: <span className='font-bold text-sm text-dynamic' />,
+                    }}
+                  />
                 </p>
               </div>
             )}


### PR DESCRIPTION
### Description
<!-- Briefly describe the changes in this PR -->

### Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->