### PR TITLE
fix(ui): use i18n key comparison for sidebar section header margin

### DIFF
--- a/src/shared/components/Sidebar.tsx
+++ b/src/shared/components/Sidebar.tsx
@@ -126,7 +126,7 @@ export const Sidebar = () => {
         className={cn(
           'px-4 py-1 mb-0 text-[12px] font-bold text-content uppercase tracking-wider select-none',
           'transition-all ease-in-out whitespace-nowrap truncate',
-          header !== 'Games' ? 'mt-4' : 'mt-0',
+          header !== t('sidebar.section.games') ? 'mt-4' : 'mt-0',
         )}
       >
         {header}


### PR DESCRIPTION
### Description
<!-- Briefly describe the changes in this PR -->

### Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->