### PR TITLE
fix(ui): close search modal with escape when empty

### DIFF
--- a/src/shared/components/SearchModal.tsx
+++ b/src/shared/components/SearchModal.tsx
@@ -105,12 +105,22 @@ export const SearchModal = ({ isModalOpen = false, onModalClose }: SearchModalPr
   }
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    const { value } = e.currentTarget
+
     if (e.key === 'Enter') {
-      const target = e.target as HTMLInputElement
-      applySearchQuery(target.value)
-      saveSearchQuery(target.value)
+      applySearchQuery(value)
+      saveSearchQuery(value)
       searchStore.setIsQuery(true)
       onModalClose?.()
+    }
+
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      if (value) {
+        handleClear()
+      } else {
+        onModalClose?.()
+      }
     }
   }
 


### PR DESCRIPTION
### Description
Updates the search modal Escape key behavior. Pressing Escape still clears the current search text when the input has a value, but now closes the search modal when the input is already empty.

### Issue
Currently, when the search modal is open, pressing Escape clears the input if it contains text. However, if the input is already empty, pressing Escape does nothing, so the modal can only be closed with the mouse. I would expect the modal to close in that case, so this behavior feels like a bug.