### PR TITLE
fix(tauri): prevent shutdown error popup from process cleanup on exit

### DIFF
--- a/docs/changelogs/5.3.3.mdx
+++ b/docs/changelogs/5.3.3.mdx
@@ -1,0 +1,8 @@
+---
+title: 5.3.3
+date: 2026-06-08
+tags: ['Fixed']
+---
+
+### Fixed 🐛
+- Fixed an issue where shutting down Windows while SGI was open could show an error popup that had to be manually dismissed before shutdown would continue

--- a/src-tauri/src/idling.rs
+++ b/src-tauri/src/idling.rs
@@ -36,7 +36,12 @@ pub async fn start_idle(app_id: u32, app_name: String) -> Result<Value, String> 
 
     {
         let mut processes = SPAWNED_PROCESSES.lock().map_err(|e| e.to_string())?;
-        processes.push(ProcessInfo { child, app_id, pid, source: "idle".to_string() });
+        processes.push(ProcessInfo {
+            child,
+            app_id,
+            pid,
+            source: "idle".to_string(),
+        });
     }
 
     tokio::time::sleep(Duration::from_millis(1000)).await;
@@ -150,7 +155,11 @@ pub async fn start_farm_idle(games_list: Vec<GameInfo>) -> Result<Value, String>
 pub async fn stop_farm_idle() -> Result<Value, String> {
     let pids: Vec<u32> = {
         let processes = SPAWNED_PROCESSES.lock().map_err(|e| e.to_string())?;
-        processes.iter().filter(|p| p.source == "farm").map(|p| p.pid).collect()
+        processes
+            .iter()
+            .filter(|p| p.source == "farm")
+            .map(|p| p.pid)
+            .collect()
     };
 
     if !pids.is_empty() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -170,9 +170,7 @@ pub fn run() {
         .run(move |_, event| match event {
             tauri::RunEvent::Exit => {
                 // Kill all SteamUtil processes on app exit
-                tauri::async_runtime::block_on(async {
-                    let _ = kill_all_steamutil_processes().await;
-                });
+                kill_tracked_processes_blocking();
             }
             _ => {}
         });

--- a/src-tauri/src/process_handler.rs
+++ b/src-tauri/src/process_handler.rs
@@ -165,6 +165,16 @@ pub async fn kill_all_steamutil_processes() -> Result<Value, String> {
     }
 }
 
+// Kill tracked SteamUtility processes via their existing handles
+pub fn kill_tracked_processes_blocking() {
+    if let Ok(mut processes) = SPAWNED_PROCESSES.lock() {
+        for process in processes.iter_mut() {
+            let _ = process.child.kill();
+        }
+        processes.clear();
+    }
+}
+
 // Helper function to clean up dead processes
 pub fn cleanup_dead_processes() -> Result<(), String> {
     let mut processes = SPAWNED_PROCESSES.lock().map_err(|e| e.to_string())?;


### PR DESCRIPTION
### Description
<!-- Briefly describe the changes in this PR -->

### Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->