### PR TITLE
fix(custom-lists): retain selected sort option when switching tabs

### DIFF
--- a/src/features/custom-lists/components/CustomList.tsx
+++ b/src/features/custom-lists/components/CustomList.tsx
@@ -505,7 +505,7 @@ export const CustomList = ({ type }: CustomListProps) => {
                       ),
                       popoverContent: ['bg-input rounded-xl justify-start !text-content'],
                     }}
-                    defaultSelectedKeys={['a-z']}
+                    selectedKeys={[sortStyle]}
                     onSelectionChange={e => {
                       if (e.currentKey) setSortStyle(e.currentKey)
                     }}


### PR DESCRIPTION
### Description
<!-- Briefly describe the changes in this PR -->

### Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->