### PR TITLE
feat(card-farming): add global max card farming time setting

### DIFF
--- a/docs/app/(marketing)/docs/_content/settings/game-settings.mdx
+++ b/docs/app/(marketing)/docs/_content/settings/game-settings.mdx
@@ -23,6 +23,22 @@ This only applies to games idled by [Playtime Booster](/docs/features/playtime-b
 
 Set to `0` to idle indefinitely.
 
+## Global Max Card Farming Time
+
+Set a default maximum farming time (in minutes) that applies to all games. Individual per-game limits take priority over this value when set.
+
+This only applies to games farmed by [Card Farming](/docs/features/card-farming). It has no effect on games idled by [Playtime Booster](/docs/features/playtime-booster), [Automatic Idler](/docs/features/auto-idler), or games running through [Achievement Unlocker](/docs/features/achievement-unlocker).
+
+Set to `0` to farm indefinitely.
+
+## Max Card Farming Time
+
+Set the maximum farming time (in minutes) for the selected game. SGI will stop farming this game when the time limit is reached.
+
+This only applies to games farmed by [Card Farming](/docs/features/card-farming). It has no effect on games idled by [Playtime Booster](/docs/features/playtime-booster), [Automatic Idler](/docs/features/auto-idler), or games running through [Achievement Unlocker](/docs/features/achievement-unlocker).
+
+Set to `0` to farm indefinitely.
+
 ## Max Card Drops
 
 Set the maximum number of card drops to farm for the selected game before stopping.

--- a/docs/changelogs/5.4.4.mdx
+++ b/docs/changelogs/5.4.4.mdx
@@ -1,0 +1,8 @@
+---
+title: 5.4.4
+date: 2026-07-03
+tags: ['New']
+---
+
+### New 🎉
+- Added a **Global Max Card Farming Time** setting to **Settings > Game Settings**, allowing users to set a default maximum farming duration that applies to all games in the **Card Farming** feature

--- a/src/features/card-farming/hooks/useCardFarming.ts
+++ b/src/features/card-farming/hooks/useCardFarming.ts
@@ -294,6 +294,15 @@ const processGamesWithDrops = (
           maxCardFarmingTime = gameSetting.maxCardFarmingTime ?? 0
         }
 
+        // Check for globalMaxCardFarmingTime first
+        const globalMaxCardFarmingTime =
+          typeof gameSettings.globalMaxCardFarmingTime === 'number'
+            ? gameSettings.globalMaxCardFarmingTime
+            : 0
+        if (globalMaxCardFarmingTime > 0) {
+          maxCardFarmingTime = globalMaxCardFarmingTime
+        }
+
         if (maxCardFarmingTime > 0) {
           if (!(gameId in farmStartTimes)) {
             farmStartTimes[gameId] = Date.now()
@@ -380,6 +389,15 @@ const processIndividualGames = async (
         ) {
           maxCardDrops = gameSetting.maxCardDrops ?? dropsRemaining
           maxCardFarmingTime = gameSetting.maxCardFarmingTime ?? 0
+        }
+
+        // Check for globalMaxCardFarmingTime first
+        const globalMaxCardFarmingTime =
+          typeof gameSettings.globalMaxCardFarmingTime === 'number'
+            ? gameSettings.globalMaxCardFarmingTime
+            : 0
+        if (globalMaxCardFarmingTime > 0) {
+          maxCardFarmingTime = globalMaxCardFarmingTime
         }
 
         if (maxCardFarmingTime > 0) {
@@ -542,6 +560,16 @@ const checkDropsRemaining = async (gameSet: Set<GameWithDrops>) => {
       if (typeof gameSetting === 'object' && gameSetting !== null && !Array.isArray(gameSetting)) {
         maxCardFarmingTime = gameSetting.maxCardFarmingTime ?? 0
       }
+
+      // Check for globalMaxCardFarmingTime first
+      const globalMaxCardFarmingTime =
+        typeof gameSettings.globalMaxCardFarmingTime === 'number'
+          ? gameSettings.globalMaxCardFarmingTime
+          : 0
+      if (globalMaxCardFarmingTime > 0) {
+        maxCardFarmingTime = globalMaxCardFarmingTime
+      }
+
       const elapsedMs = game.appid in farmStartTimes ? Date.now() - farmStartTimes[game.appid] : 0
 
       if (dropsRemaining <= 0) {

--- a/src/features/settings/components/game-settings/GameSettings.tsx
+++ b/src/features/settings/components/game-settings/GameSettings.tsx
@@ -70,10 +70,12 @@ export const GameSettings = () => {
 
   const {
     globalMaxIdleTime,
+    globalMaxCardFarmingTime,
     maxIdleTime,
     maxCardDrops,
     maxCardFarmingTime,
     handleGlobalMaxIdleTimeChange,
+    handleGlobalMaxCardFarmingTimeChange,
     maxAchievementUnlocks,
     handleMaxIdleTimeChange,
     handleMaxCardDropsChange,
@@ -207,6 +209,40 @@ export const GameSettings = () => {
               stepperButton: ['!text-content', 'text-sm'],
             }}
             onValueChange={handleMaxIdleTimeChange}
+          />
+        </div>
+
+        <Divider className='bg-border/70 my-4' />
+
+        <div className='flex justify-between items-center'>
+          <div className='flex flex-col gap-2 w-1/2'>
+            <p className='text-sm text-content font-bold'>
+              {t('gameSettings.globalCardFarmingTime')}
+            </p>
+            <p className='text-xs text-altwhite'>{t('gameSettings.globalCardFarmingTimeSub')}</p>
+          </div>
+          <NumberInput
+            size='sm'
+            value={globalMaxCardFarmingTime}
+            isDisabled={!!selectedGame}
+            step={1}
+            minValue={0}
+            maxValue={99999}
+            aria-label='global max card farming time'
+            className='w-22.5'
+            classNames={{
+              inputWrapper: cn(
+                'bg-input data-[hover=true]:!bg-inputhover border-none',
+                'group-data-[focus-visible=true]:ring-transparent',
+                'group-data-[focus-visible=true]:ring-offset-transparent',
+                'group-data-[focus-within=true]:!bg-inputhover',
+                'border group-data-[invalid=true]:border-red-500!',
+                'border group-data-[invalid=true]:bg-red-500/10!',
+              ),
+              input: ['text-sm !text-content'],
+              stepperButton: ['!text-content', 'text-sm'],
+            }}
+            onValueChange={handleGlobalMaxCardFarmingTimeChange}
           />
         </div>
 

--- a/src/features/settings/hooks/game-settings/useGameSettings.ts
+++ b/src/features/settings/hooks/game-settings/useGameSettings.ts
@@ -16,6 +16,7 @@ export function useGameSettings({ appId }: UseGameSettingsProps = {}) {
   const [maxCardFarmingTime, setMaxCardFarmingTime] = useState(0)
   const [maxAchievementUnlocks, setMaxAchievementUnlocks] = useState(0)
   const [globalMaxIdleTime, setGlobalMaxIdleTime] = useState(0)
+  const [globalMaxCardFarmingTime, setGlobalMaxCardFarmingTime] = useState(0)
   const isInitializedRef = useRef(false)
 
   function isGameSpecificSettings(val: unknown) {
@@ -39,6 +40,11 @@ export function useGameSettings({ appId }: UseGameSettingsProps = {}) {
       setGlobalMaxIdleTime(
         (userSettings.gameSettings &&
           (userSettings.gameSettings as GameSettings).globalMaxIdleTime) ||
+          0,
+      )
+      setGlobalMaxCardFarmingTime(
+        (userSettings.gameSettings &&
+          (userSettings.gameSettings as GameSettings).globalMaxCardFarmingTime) ||
           0,
       )
       isInitializedRef.current = true
@@ -130,6 +136,25 @@ export function useGameSettings({ appId }: UseGameSettingsProps = {}) {
     saveGlobalMaxIdleTime(newValue)
   }
 
+  const saveGlobalMaxCardFarmingTime = async (value: number) => {
+    const gameSettings = { ...(userSettings.gameSettings || {}) }
+    ;(gameSettings as GameSettings).globalMaxCardFarmingTime = value
+
+    const updateResponse = await invoke<InvokeSettings>('update_user_settings', {
+      steamId: userSummary?.steamId,
+      key: 'gameSettings',
+      value: gameSettings,
+    })
+
+    setUserSettings(updateResponse.settings)
+  }
+
+  const handleGlobalMaxCardFarmingTimeChange = (value: number) => {
+    const newValue = value || 0
+    setGlobalMaxCardFarmingTime(newValue)
+    saveGlobalMaxCardFarmingTime(newValue)
+  }
+
   const resetSettings = () => {
     if (!appId) {
       setMaxIdleTime(0)
@@ -166,5 +191,8 @@ export function useGameSettings({ appId }: UseGameSettingsProps = {}) {
     globalMaxIdleTime,
     setGlobalMaxIdleTime,
     handleGlobalMaxIdleTimeChange,
+    globalMaxCardFarmingTime,
+    setGlobalMaxCardFarmingTime,
+    handleGlobalMaxCardFarmingTimeChange,
   }
 }

--- a/src/i18n/locales/en-US/translation.json
+++ b/src/i18n/locales/en-US/translation.json
@@ -124,6 +124,8 @@
   "cardMenu.store": "View store page",
   "gameSettings.globalMaxIdle": "Global Max Idle Time",
   "gameSettings.globalMaxIdleSub": "The maximum amount of time (in minutes) that all games idled by Playtime Booster and Achievement Unlocker should be idled for before stopping (overrides individual game settings)",
+  "gameSettings.globalCardFarmingTime": "Global Max Card Farming Time",
+  "gameSettings.globalCardFarmingTimeSub": "The maximum amount of time (in minutes) that all games should be farmed for by Card Farming before stopping (overrides individual game settings)",
   "gameSettings.idle": "Max Idle Time",
   "gameSettings.idleSub": "The maximum amount of time (in minutes) that this game should be idled for by Playtime Booster and Achievement Unlocker before stopping",
   "gameSettings.drops": "Max Card Drops",

--- a/src/shared/types/settings.ts
+++ b/src/shared/types/settings.ts
@@ -48,6 +48,7 @@ export interface GameSpecificSettings {
 
 export interface GameSettings {
   globalMaxIdleTime?: number
+  globalMaxCardFarmingTime?: number
   [appId: string]: GameSpecificSettings | number | undefined
 }
 


### PR DESCRIPTION
### Description
<!-- Briefly describe the changes in this PR -->

### Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->