### PR TITLE
feat(card-farming): add queue order option to farming order setting

### DIFF
--- a/docs/changelogs/6.0.8.mdx
+++ b/docs/changelogs/6.0.8.mdx
@@ -6,7 +6,8 @@ tags: ['New', 'Improved', 'Fixed']
 
 ### New 🎉
 - Added support for the **Italian** language. If you'd like to help translate SGI into your language, see the [contribution guide](https://github.com/zevnda/steam-game-idler/discussions/148)
-- Added a new **Single farming mode** setting for **Card Farming** — enable it to farm one game at a time instead of many at once, which can sometimes help games drop cards faster. Your farming queue can still hold as many games as you like either way, SGI just works through them one by one
+- Added a new **Single farming mode** setting for **Card Farming**. Enable it to farm one game at a time instead of many at once, which can sometimes help games drop cards faster. Your farming queue can still hold as many games as you like either way, SGI just works through them one by one
+- Added a new **Queue order** option to the **Farming order** section in **Settings > Card Farming**. When enabled, SGI farms games in the order you've arranged them in your queue via drag-and-drop, instead of always resorting by drops remaining
 
 ### Improved 🚀
 - Log files older than 7 days are now automatically deleted on launch, preventing them from accumulating indefinitely

--- a/src-tauri/src/card_farming/manager.rs
+++ b/src-tauri/src/card_farming/manager.rs
@@ -117,7 +117,19 @@ async fn fetch_queued_games(
     }
 
     let drop_sort_order = settings::get(app_handle, steam_id).await?.drop_sort_order;
-    sort_by_drop_order(&mut games, drop_sort_order);
+    // Only read the persisted queue's order when it's actually going to be used - `all_games`
+    // mode farms games that were never added to this queue at all, so a read here would just be
+    // wasted I/O for a position lookup `sort_by_drop_order` will never find a match for anyway.
+    let queue_order: Vec<u32> = if drop_sort_order == settings::DropSortOrder::QueueOrder {
+        queue::read(app_handle, steam_id)
+            .await?
+            .into_iter()
+            .map(|entry| entry.app_id)
+            .collect()
+    } else {
+        Vec::new()
+    };
+    sort_by_drop_order(&mut games, drop_sort_order, &queue_order);
     Ok((games, excluded))
 }
 
@@ -135,12 +147,27 @@ fn playtime_lookup(app_handle: &AppHandle, steam_id: &str) -> HashMap<u32, u64> 
 
 /// Pure sort step split out of [`fetch_queued_games`] so it's unit-testable without the
 /// network/settings-file I/O around it - mirrors `is_capped`'s split for the same reason.
-fn sort_by_drop_order(games: &mut [GameWithDrops], order: settings::DropSortOrder) {
+/// `queue_order` is the account's persisted queue, app-id-only, in the user's drag-reordered
+/// sequence - only consulted for [`settings::DropSortOrder::QueueOrder`]; empty otherwise. Uses
+/// `sort_by_key` (a stable sort) rather than `sort_by`, so a game with no entry in `queue_order`
+/// (e.g. `all_games` mode, which never populates the queue at all) falls back to whatever relative
+/// order the scraper returned it in rather than being reshuffled against every other such game.
+fn sort_by_drop_order(
+    games: &mut [GameWithDrops],
+    order: settings::DropSortOrder,
+    queue_order: &[u32],
+) {
     match order {
         settings::DropSortOrder::HighestFirst => {
             games.sort_by(|a, b| b.remaining.cmp(&a.remaining))
         }
         settings::DropSortOrder::LowestFirst => games.sort_by(|a, b| a.remaining.cmp(&b.remaining)),
+        settings::DropSortOrder::QueueOrder => games.sort_by_key(|g| {
+            queue_order
+                .iter()
+                .position(|&app_id| app_id == g.app_id)
+                .unwrap_or(usize::MAX)
+        }),
     }
 }
 
@@ -890,7 +917,7 @@ mod tests {
     #[test]
     fn sort_by_drop_order_highest_first_orders_by_descending_remaining() {
         let mut games = vec![game(1, 3), game(2, 10), game(3, 1)];
-        sort_by_drop_order(&mut games, settings::DropSortOrder::HighestFirst);
+        sort_by_drop_order(&mut games, settings::DropSortOrder::HighestFirst, &[]);
         assert_eq!(
             games.iter().map(|g| g.app_id).collect::<Vec<_>>(),
             vec![2, 1, 3]
@@ -900,10 +927,37 @@ mod tests {
     #[test]
     fn sort_by_drop_order_lowest_first_orders_by_ascending_remaining() {
         let mut games = vec![game(1, 3), game(2, 10), game(3, 1)];
-        sort_by_drop_order(&mut games, settings::DropSortOrder::LowestFirst);
+        sort_by_drop_order(&mut games, settings::DropSortOrder::LowestFirst, &[]);
         assert_eq!(
             games.iter().map(|g| g.app_id).collect::<Vec<_>>(),
             vec![3, 1, 2]
+        );
+    }
+
+    #[test]
+    fn sort_by_drop_order_queue_order_orders_by_queue_position() {
+        let mut games = vec![game(1, 3), game(2, 10), game(3, 1)];
+        sort_by_drop_order(
+            &mut games,
+            settings::DropSortOrder::QueueOrder,
+            &[3, 1, 2],
+        );
+        assert_eq!(
+            games.iter().map(|g| g.app_id).collect::<Vec<_>>(),
+            vec![3, 1, 2]
+        );
+    }
+
+    #[test]
+    fn sort_by_drop_order_queue_order_appends_unqueued_games_in_original_order() {
+        let mut games = vec![game(1, 3), game(2, 10), game(3, 1)];
+        // Only app 2 has a known queue position - the rest (1, 3) aren't in `queue_order` at all
+        // (mirrors `all_games` mode, which never populates the queue) and should keep their
+        // original relative order rather than being reshuffled against each other.
+        sort_by_drop_order(&mut games, settings::DropSortOrder::QueueOrder, &[2]);
+        assert_eq!(
+            games.iter().map(|g| g.app_id).collect::<Vec<_>>(),
+            vec![2, 1, 3]
         );
     }
 

--- a/src-tauri/src/card_farming/queue.rs
+++ b/src-tauri/src/card_farming/queue.rs
@@ -108,7 +108,10 @@ pub async fn remove(
     Ok(queue)
 }
 
-/// Bulk-replaces the whole queue, preserving the given order - used after drag-reorder.
+/// Bulk-replaces the whole queue, preserving the given order - used after drag-reorder. This order
+/// is read back by `manager::fetch_queued_games` when the account's `DropSortOrder::QueueOrder`
+/// setting is active (the default), so a drag-reorder here directly changes the order games are
+/// farmed in, not just their display order.
 pub async fn set_order(
     app_handle: &AppHandle,
     steam_id: &str,

--- a/src-tauri/src/card_farming/settings.rs
+++ b/src-tauri/src/card_farming/settings.rs
@@ -48,14 +48,20 @@ const SETTINGS_FILE_NAME: &str = "card_farming_settings.json";
 
 static WRITE_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
-/// Which end of the drops-remaining range to farm first - was two mutually-exclusive booleans
+/// Which order to farm queued games in - was two mutually-exclusive booleans
 /// (`sort_by_highest_drops`/`sort_by_lowest_drops`, one always forced off when the other turned
 /// on), collapsed into a real enum matching `inventory::settings::PricePreference`'s pattern (a
-/// two-option preference that's always exactly one value, never both-off/both-on).
+/// multi-option preference that's always exactly one value, never both-off/both-on).
+/// `QueueOrder` (the default) farms games in the order they appear in the account's curated
+/// card-farming queue (`queue.rs`) - drag-reorder on the Queue tab only had any actual effect on
+/// farming order once this variant existed; before it, the queue's order was purely cosmetic and
+/// every farm always resorted by drop count. `HighestFirst`/`LowestFirst` still resort by the
+/// scraped drop count instead, ignoring the queue's own order.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum DropSortOrder {
     #[default]
+    QueueOrder,
     HighestFirst,
     LowestFirst,
 }
@@ -110,7 +116,7 @@ impl Default for CardFarmingSettings {
             all_games: true,
             skip_no_playtime: false,
             farm_unplayed_only: false,
-            drop_sort_order: DropSortOrder::HighestFirst,
+            drop_sort_order: DropSortOrder::QueueOrder,
             next_task_checkbox: false,
             next_task: None,
             auto_farm_cards: false,

--- a/src/features/card-farming/components/CardFarmingSettingsTab.tsx
+++ b/src/features/card-farming/components/CardFarmingSettingsTab.tsx
@@ -11,7 +11,7 @@ import { useProModalStore } from '@/shared/stores/proModalStore'
 import { useSubscriptionStore } from '@/shared/stores/subscriptionStore'
 import { hasGamerAccess } from '@/shared/utils/subscriptionAccess'
 
-const DROP_SORT_ORDERS: DropSortOrder[] = ['highestFirst', 'lowestFirst']
+const DROP_SORT_ORDERS: DropSortOrder[] = ['queueOrder', 'highestFirst', 'lowestFirst']
 
 interface CardFarmingSettingsTabProps {
   settings: CardFarmingSettings | null

--- a/src/features/card-farming/types.ts
+++ b/src/features/card-farming/types.ts
@@ -68,9 +68,11 @@ export const DEFAULT_FARMING_STATE: FarmingState = {
   sessionExpired: false,
 }
 
-// Mirrors src-tauri/src/card_farming/settings.rs::DropSortOrder - a two-option preference (like
-// inventory-manager's PricePreference), not two independent booleans.
-export type DropSortOrder = 'highestFirst' | 'lowestFirst'
+// Mirrors src-tauri/src/card_farming/settings.rs::DropSortOrder - a multi-option preference (like
+// inventory-manager's PricePreference), not independent booleans. `queueOrder` (the default) farms
+// games in the order they appear in the account's curated card-farming queue (drag-reorderable on
+// the Queue tab); `highestFirst`/`lowestFirst` ignore the queue's order and resort by drop count.
+export type DropSortOrder = 'queueOrder' | 'highestFirst' | 'lowestFirst'
 
 // Mirrors src-tauri/src/card_farming/settings.rs::CardFarmingSettings. Blacklisting now lives in
 // its own list (`CardFarmingBlacklistEntry`/`useCardFarmingBlacklist`, backed by its own file) -

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -668,9 +668,10 @@
           "description": "Only farm games that have zero recorded playtime."
         },
         "dropSortOrder": {
-          "title": "Drop order",
-          "description": "Which games to farm first when queuing by card drops remaining.",
+          "title": "Farming order",
+          "description": "Choose which order games in the queue should be farmed in.",
           "options": {
+            "queueOrder": "Queue order",
             "highestFirst": "Highest drops first",
             "lowestFirst": "Lowest drops first"
           }


### PR DESCRIPTION
### Description
<!-- Briefly describe the changes in this PR -->

### Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->