### PR TITLE
fix(account-switcher): clear active search query on account switch or sign-out

### DIFF
--- a/docs/changelogs/6.0.8.mdx
+++ b/docs/changelogs/6.0.8.mdx
@@ -7,12 +7,14 @@ tags: ['New', 'Improved', 'Fixed']
 ### New 🎉
 - Added support for the **Italian** language. If you'd like to help translate SGI into your language, see the [contribution guide](https://github.com/zevnda/steam-game-idler/discussions/148)
 - Added a new **Single farming mode** setting for **Card Farming**. Enable it to farm one game at a time instead of many at once, which can sometimes help games drop cards faster. Your farming queue can still hold as many games as you like either way, SGI just works through them one by one
+  - This is a **Beta** feature, if you experience any issues while using it, please [open an issue on GitHub](https://github.com/zevnda/steam-game-idler/issues/new?template=issue_report.yml)
 - Added a new **Skip refundable games** setting for **Card Farming** (**Sign in with Steam** mode only). Enable it to avoid farming a game that's still within Steam's refund window (bought within the last 14 days with under 2 hours of playtime), so idling for card drops doesn't eat into your ability to refund it. The game farms normally again once either limit is reached
 - Added a new **Queue order** option to the **Farming order** section for **Card Farming** settings. When enabled, SGI farms games in the order you've arranged them in your queue via drag-and-drop, instead of always resorting by drops remaining
+- Added a new **Show games only** setting in **Settings > General** for **Sign in with Steam** mode. Enabled by default, it hides DLC, soundtracks, videos, and tools from your games list so it only shows games and family-shared games, matching what **Legacy Sign In** mode already shows. Disable it to see everything you own instead
 
 ### Improved 🚀
-- Log files older than 7 days are now automatically deleted on launch, preventing them from accumulating indefinitely
 - Achievement names and descriptions in the **Achievement Manager** and **Achievement Unlocker** now use your selected language when signed in with **Sign in with Steam**, for games whose developer has actually translated their achievements into that language
+- Log files older than 7 days are now automatically deleted on launch, preventing them from accumulating indefinitely
 
 ### Fixed 🐛
 - Fixed an issue where the **Sign-in** screen would briefly flash on screen before loading into the dashboard when relaunching the app while already signed in

--- a/libs/SteamUtility/Backends/SteamKitRemoteBackend.cs
+++ b/libs/SteamUtility/Backends/SteamKitRemoteBackend.cs
@@ -74,8 +74,10 @@ namespace SteamUtility.Backends
             // PICS-based ownership resolves the account's full owned library itself - it has no
             // concept of "checking a candidate list", unlike the local-client backend's
             // BIsSubscribedApp loop. candidateAppIds is accepted for interface parity but ignored;
-            // the whitelist filter inside GetOwnedGamesAsync already narrows to real games.
-            var games = await _ownershipManager.GetOwnedGamesAsync(_bot);
+            // gamesOnly: true asks GetOwnedGamesAsync to apply the same whitelist filter
+            // SteamworksLocalBackend's own candidate list uses, so this backend's ownership scope
+            // matches it exactly.
+            var games = await _ownershipManager.GetOwnedGamesAsync(_bot, gamesOnly: true);
             return games.ToList();
         }
     }

--- a/libs/SteamUtility/Daemon/Bot/OwnershipManager.cs
+++ b/libs/SteamUtility/Daemon/Bot/OwnershipManager.cs
@@ -7,6 +7,7 @@ using SteamKit2.Internal;
 using SteamUtility.Core.Errors;
 using SteamUtility.Core.Logging;
 using SteamUtility.Core.Models;
+using SteamUtility.Core.Services;
 
 namespace SteamUtility.Daemon.Bot
 {
@@ -14,6 +15,8 @@ namespace SteamUtility.Daemon.Bot
     // Steam client needed. Correctly reflects Family Sharing / borrowed games.
     public sealed class OwnershipManager
     {
+        private readonly GameWhitelistProvider _whitelistProvider = new();
+
         // Payment methods that were never an actual money transaction through Steam's checkout -
         // Steam's refund policy has nothing to refund for these regardless of how recently the
         // license was granted, so they're excluded entirely from "recently purchased" tracking
@@ -44,21 +47,23 @@ namespace SteamUtility.Daemon.Bot
             Dictionary<uint, DateTime> LastRefundEligiblePurchaseUtcByAppId
         );
 
-        public async Task<IReadOnlyList<OwnedGame>> GetOwnedGamesAsync(SteamBot bot)
+        public async Task<IReadOnlyList<OwnedGame>> GetOwnedGamesAsync(SteamBot bot, bool gamesOnly)
         {
             if (!bot.IsLoggedOn)
             {
                 throw new NotLoggedOnException();
             }
 
-            // Deliberately unfiltered: every PICS-resolved app id tied to an owned license comes
-            // through as-is (games, videos/movies, DLC, tools, demos, soundtracks) - agent mode has
-            // no curated-whitelist dependency the way CLI mode's SteamworksLocalBackend does, so
-            // there's no ownership-check reason to intersect against GameWhitelistProvider here.
-            // This intentionally surfaces non-game owned content (e.g. Steam movies like
-            // 518440/518450) that the whitelist used to drop. CLI mode is unaffected - it still
-            // depends on the whitelist as its only ownership-check candidate list, see
-            // SteamworksLocalBackend.CheckOwnershipAsync.
+            // By default (gamesOnly: false) this is deliberately unfiltered: every PICS-resolved
+            // app id tied to an owned license comes through as-is (games, videos/movies, DLC,
+            // tools, demos, soundtracks) - some users specifically want this, including non-game
+            // owned content (e.g. Steam movies like 518440/518450) that the whitelist would drop.
+            // When gamesOnly is true (a user-facing setting - see
+            // src-tauri/src/steam_agent/ownership_settings.rs), the resolved app ids are
+            // intersected against the same curated GameWhitelistProvider candidate list CLI mode's
+            // SteamworksLocalBackend.CheckOwnershipAsync always uses, matching CLI mode's scope
+            // exactly. Family Sharing / borrowed games are unaffected either way - that's inherent
+            // to bot.OwnedLicenses below, not something either mode filters.
 
             // LicenseListCallback (what OwnedLicenses below is built from) is a separate server
             // push with no ordering guarantee relative to the login success this call is triggered
@@ -68,10 +73,17 @@ namespace SteamUtility.Daemon.Bot
             await bot.WaitForLicenseListAsync(TimeSpan.FromSeconds(10));
             var resolution = await ResolveOwnedAppIdsAsync(bot);
 
-            var games = new List<OwnedGame>();
-            if (resolution.AppIds.Count > 0)
+            var appIds = resolution.AppIds;
+            if (gamesOnly)
             {
-                var appRequests = resolution.AppIds
+                var whitelist = await _whitelistProvider.GetWhitelistAsync();
+                appIds = new HashSet<uint>(appIds.Where(whitelist.Contains));
+            }
+
+            var games = new List<OwnedGame>();
+            if (appIds.Count > 0)
+            {
+                var appRequests = appIds
                     .Select(appId => new SteamApps.PICSRequest(appId))
                     .ToList();
 

--- a/libs/SteamUtility/Daemon/DaemonHost.cs
+++ b/libs/SteamUtility/Daemon/DaemonHost.cs
@@ -203,7 +203,10 @@ namespace SteamUtility.Daemon
 
                     case "get_owned_apps":
                     {
-                        var games = await _ownershipManager.GetOwnedGamesAsync(_bot);
+                        var games = await _ownershipManager.GetOwnedGamesAsync(
+                            _bot,
+                            request.GamesOnly ?? false
+                        );
                         IpcServer.SendResponse(request.Id, true, new { games });
                         break;
                     }

--- a/libs/SteamUtility/Daemon/Ipc/IpcMessage.cs
+++ b/libs/SteamUtility/Daemon/Ipc/IpcMessage.cs
@@ -35,5 +35,11 @@ namespace SteamUtility.Daemon.Ipc
         // `achievements_get` only - a Steam schema language key (e.g. "english", "schinese"),
         // pre-mapped Rust-side from the app's own locale. See AchievementHandler.GetAchievementsAndStatsAsync.
         public string? Language { get; set; }
+
+        // `get_owned_apps` only - when true, intersect the PICS-resolved owned app ids against the
+        // same curated whitelist CLI mode's SteamworksLocalBackend uses as its ownership-check
+        // candidate list, so agent mode can match CLI mode's "games only" scope. See
+        // OwnershipManager.GetOwnedGamesAsync.
+        public bool? GamesOnly { get; set; }
     }
 }

--- a/src-tauri/src/debug/commands.rs
+++ b/src-tauri/src/debug/commands.rs
@@ -13,6 +13,7 @@ use crate::inventory::settings::InventorySettings;
 use crate::logging;
 use crate::platform;
 use crate::settings::{self, commands::SettingsResponse};
+use crate::steam_agent::ownership_settings::OwnershipSettings;
 use crate::steam_agent::AgentManager;
 
 /// `tracing_appender::rolling::daily` names files by prefix + rotation date, so there's no fixed
@@ -138,6 +139,9 @@ pub struct ResetSettingsResult {
     pub inventory_settings: Option<InventorySettings>,
     pub card_farming_settings: Option<CardFarmingSettings>,
     pub free_games_settings: Option<FreeGamesSettings>,
+    /// `None` for a CLI-mode account too (not just no account) - this setting has no CLI-mode
+    /// equivalent, see `steam_agent::ownership_settings`'s module doc comment.
+    pub ownership_settings: Option<OwnershipSettings>,
 }
 
 /// Resets every app-wide setting (`settings.json` via `settings::reset`, the Steam Web API key
@@ -182,9 +186,28 @@ pub async fn reset_settings(
         inventory_settings,
         card_farming_settings,
         free_games_settings,
+        ownership_settings,
     ) = match account {
         Some(account) => {
             let steam_id = resolve_steam_id(&account, &agent_manager).await?;
+            // Agent-mode only - CLI mode has no `ownership_settings.json` at all (see that
+            // module's doc comment), so resetting it for a CLI-mode account would just create an
+            // unused file.
+            let ownership = match &account {
+                GamesAccount::Agent { .. } => Some(
+                    crate::steam_agent::ownership_settings::set(
+                        &app_handle,
+                        &steam_id,
+                        OwnershipSettings::default(),
+                    )
+                    .await
+                    .map_err(|e| {
+                        tracing::warn!(steam_id, error = %e, "settings reset: failed to reset ownership settings");
+                        e
+                    })?,
+                ),
+                GamesAccount::Local { .. } => None,
+            };
             // `reset` (not `set`) for achievement-unlocker/card-farming - `set` deliberately only
             // touches `.settings` on their own writes, leaving per-game overrides/caps alone (see
             // each module's doc comment), so a full reset needs the dedicated wipe entry point or
@@ -242,9 +265,10 @@ pub async fn reset_settings(
                 Some(inventory),
                 Some(card_farming),
                 Some(free_games),
+                ownership,
             )
         }
-        None => (None, None, None, None),
+        None => (None, None, None, None, None),
     };
 
     tracing::info!(had_account, "settings reset: completed");
@@ -255,5 +279,6 @@ pub async fn reset_settings(
         inventory_settings,
         card_farming_settings,
         free_games_settings,
+        ownership_settings,
     })
 }

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -103,6 +103,9 @@ pub enum AppError {
     #[error("failed to read/write the presence settings cache: {0}")]
     PresenceSettingsIo(String),
 
+    #[error("failed to read/write the ownership settings cache: {0}")]
+    OwnershipSettingsIo(String),
+
     #[error("failed to read/write a custom achievement order file: {0}")]
     AchievementOrderIo(String),
 
@@ -260,6 +263,7 @@ impl AppError {
                 "achievement_unlocker_settings_io_failed".to_string()
             }
             AppError::PresenceSettingsIo(_) => "presence_settings_io_failed".to_string(),
+            AppError::OwnershipSettingsIo(_) => "ownership_settings_io_failed".to_string(),
             AppError::AchievementOrderIo(_) => "achievement_order_io_failed".to_string(),
             AppError::PlayerProfilePrivate => "player_profile_private".to_string(),
             AppError::PlayerNoTimestamps => "player_no_timestamps".to_string(),

--- a/src-tauri/src/games/commands.rs
+++ b/src-tauri/src/games/commands.rs
@@ -75,7 +75,14 @@ pub async fn get_owned_games(
     let steam_id = resolve_steam_id(&account, &agent_manager).await?;
     let is_agent = matches!(account, GamesAccount::Agent { .. });
     let raw_games = match account {
-        GamesAccount::Agent { username } => agent_manager.get_owned_apps(&username).await?,
+        GamesAccount::Agent { username } => {
+            // Read internally rather than make every caller plumb it through - same convention as
+            // the Steam Web API key override below.
+            let games_only = crate::steam_agent::ownership_settings::get(&app_handle, &steam_id)
+                .await?
+                .games_only;
+            agent_manager.get_owned_apps(&username, games_only).await?
+        }
         GamesAccount::Local { .. } => local_steam::ownership::check_ownership().await?,
     };
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -106,6 +106,8 @@ pub fn run() {
             steam_agent::commands::agent_logout,
             steam_agent::commands::agent_get_presence_settings,
             steam_agent::commands::agent_set_presence_settings,
+            steam_agent::commands::agent_get_ownership_settings,
+            steam_agent::commands::agent_set_ownership_settings,
             platform::is_portable,
             platform::is_dev,
             updater::kill_all_steam_utility_processes,

--- a/src-tauri/src/steam_agent/commands.rs
+++ b/src-tauri/src/steam_agent/commands.rs
@@ -3,6 +3,7 @@ use tauri::{AppHandle, State};
 use crate::error::AppResult;
 
 use super::manager::{AgentManager, LoginOutcome, QrChallenge};
+use super::ownership_settings::{self, OwnershipSettings};
 use super::presence_settings::{self, PresenceSettings};
 
 /// Starts (or restarts) an agent-mode sign-in for `username`/`password`. Resolves as soon as
@@ -121,4 +122,30 @@ pub async fn agent_set_presence_settings(
     }
 
     Ok(saved)
+}
+
+/// Reads this account's saved owned-games scope setting (all content vs. games-only) - agent-mode
+/// only, no CLI-mode equivalent (CLI mode always uses the games-only whitelist).
+#[tauri::command]
+pub async fn agent_get_ownership_settings(
+    app_handle: AppHandle,
+    manager: State<'_, AgentManager>,
+    username: String,
+) -> AppResult<OwnershipSettings> {
+    let steam_id = manager.steam_id(&username).await?;
+    ownership_settings::get(&app_handle, &steam_id).await
+}
+
+/// Saves this account's owned-games scope setting. No live-apply step - unlike presence settings,
+/// this has no daemon-side effect to push; the frontend triggers a fresh `get_owned_games` fetch
+/// itself once the save resolves (see `useAgentOwnershipSettings.ts`).
+#[tauri::command]
+pub async fn agent_set_ownership_settings(
+    app_handle: AppHandle,
+    manager: State<'_, AgentManager>,
+    username: String,
+    settings: OwnershipSettings,
+) -> AppResult<OwnershipSettings> {
+    let steam_id = manager.steam_id(&username).await?;
+    ownership_settings::set(&app_handle, &steam_id, settings).await
 }

--- a/src-tauri/src/steam_agent/ipc.rs
+++ b/src-tauri/src/steam_agent/ipc.rs
@@ -53,6 +53,9 @@ pub struct IpcRequest {
     /// `SteamUtility.Daemon.Ipc.IpcRequest.Language`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub language: Option<String>,
+    /// `get_owned_apps` only - see `SteamUtility.Daemon.Ipc.IpcRequest.GamesOnly`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub games_only: Option<bool>,
 }
 
 impl IpcRequest {
@@ -73,6 +76,7 @@ impl IpcRequest {
             persona_state: None,
             game_extra_info: None,
             language: None,
+            games_only: None,
         }
     }
 
@@ -96,6 +100,7 @@ impl IpcRequest {
             persona_state: None,
             game_extra_info: None,
             language: None,
+            games_only: None,
         }
     }
 
@@ -116,6 +121,7 @@ impl IpcRequest {
             persona_state: None,
             game_extra_info: None,
             language: None,
+            games_only: None,
         }
     }
 
@@ -136,6 +142,7 @@ impl IpcRequest {
             persona_state: None,
             game_extra_info: None,
             language: None,
+            games_only: None,
         }
     }
 
@@ -156,6 +163,7 @@ impl IpcRequest {
             persona_state: None,
             game_extra_info: None,
             language: None,
+            games_only: None,
         }
     }
 
@@ -179,10 +187,11 @@ impl IpcRequest {
             persona_state: None,
             game_extra_info: None,
             language: None,
+            games_only: None,
         }
     }
 
-    pub fn get_owned_apps(id: String) -> Self {
+    pub fn get_owned_apps(id: String, games_only: bool) -> Self {
         Self {
             id,
             cmd: "get_owned_apps",
@@ -199,6 +208,7 @@ impl IpcRequest {
             persona_state: None,
             game_extra_info: None,
             language: None,
+            games_only: Some(games_only),
         }
     }
 
@@ -227,6 +237,7 @@ impl IpcRequest {
             persona_state: None,
             game_extra_info,
             language: None,
+            games_only: None,
         }
     }
 
@@ -250,6 +261,7 @@ impl IpcRequest {
             persona_state: Some(persona_state),
             game_extra_info: None,
             language: None,
+            games_only: None,
         }
     }
 
@@ -273,6 +285,7 @@ impl IpcRequest {
             persona_state: None,
             game_extra_info: None,
             language: None,
+            games_only: None,
         }
     }
 
@@ -300,6 +313,7 @@ impl IpcRequest {
             persona_state: None,
             game_extra_info: None,
             language: Some(language.to_string()),
+            games_only: None,
         }
     }
 
@@ -323,6 +337,7 @@ impl IpcRequest {
             persona_state: None,
             game_extra_info: None,
             language: None,
+            games_only: None,
         }
     }
 
@@ -347,6 +362,7 @@ impl IpcRequest {
             persona_state: None,
             game_extra_info: None,
             language: None,
+            games_only: None,
         }
     }
 
@@ -368,6 +384,7 @@ impl IpcRequest {
             persona_state: None,
             game_extra_info: None,
             language: None,
+            games_only: None,
         }
     }
 
@@ -390,6 +407,7 @@ impl IpcRequest {
             persona_state: None,
             game_extra_info: None,
             language: None,
+            games_only: None,
         }
     }
 }

--- a/src-tauri/src/steam_agent/manager.rs
+++ b/src-tauri/src/steam_agent/manager.rs
@@ -410,6 +410,11 @@ impl AgentManager {
     /// `Daemon/Bot/OwnershipManager.cs`). No playtime here - that's `games::web_api`'s job, the
     /// same Steam Web API enrichment step CLI mode's ownership check also funnels through.
     ///
+    /// `games_only` mirrors CLI mode's scope (games + family-shared, no DLC/soundtracks/videos/
+    /// tools) by asking the daemon to intersect against the same curated whitelist
+    /// `SteamworksLocalBackend` uses - see `steam_agent::ownership_settings` (defaults to `true`;
+    /// `false` opts into the unfiltered "all content" scope some users specifically want).
+    ///
     /// Uses `OWNED_APPS_REQUEST_TIMEOUT` rather than the default `send_request` timeout - unlike
     /// every other command sent through this manager, PICS-based ownership resolution scales with
     /// the account's library size (thousands of individual PICS requests for a 5,000-10,000+ game
@@ -418,11 +423,15 @@ impl AgentManager {
     pub async fn get_owned_apps(
         &self,
         username: &str,
+        games_only: bool,
     ) -> AppResult<Vec<crate::games::RawOwnedGame>> {
         let key = Self::key_for(username);
         let process = self.existing(&key).await?;
         let response = process
-            .send_request_with_timeout(IpcRequest::get_owned_apps, OWNED_APPS_REQUEST_TIMEOUT)
+            .send_request_with_timeout(
+                |id| IpcRequest::get_owned_apps(id, games_only),
+                OWNED_APPS_REQUEST_TIMEOUT,
+            )
             .await?;
 
         if !response.ok {
@@ -535,8 +544,11 @@ impl AgentManager {
     ) -> AppResult<crate::free_games::FreeGameClaimOutcome> {
         use crate::free_games::FreeGameClaimOutcome;
 
+        // Always unfiltered (games_only: false) here regardless of the user's display-scope
+        // setting - this is a real-ownership correctness check for an arbitrary promo app id
+        // (which may not be a curated "real game"), not the owned-games list shown to the user.
         let already_owned = self
-            .get_owned_apps(username)
+            .get_owned_apps(username, false)
             .await
             .map(|games| games.iter().any(|game| game.app_id == app_id))
             .unwrap_or(false);

--- a/src-tauri/src/steam_agent/mod.rs
+++ b/src-tauri/src/steam_agent/mod.rs
@@ -5,6 +5,7 @@
 pub mod commands;
 mod ipc;
 mod manager;
+pub mod ownership_settings;
 pub mod presence_settings;
 mod process;
 

--- a/src-tauri/src/steam_agent/ownership_settings.rs
+++ b/src-tauri/src/steam_agent/ownership_settings.rs
@@ -1,0 +1,106 @@
+//! Per-account owned-games scope setting - agent-mode only, no CLI-mode equivalent (CLI mode
+//! always uses the curated whitelist as its ownership-check candidate list, see
+//! `local_steam::ownership`). Steam-id-scoped file, mirroring `presence_settings`'s pattern
+//! (typed whole-struct get/set, self-healing on a corrupt/unreadable file).
+//!
+//! Agent mode's own ownership check (`OwnershipManager.GetOwnedGamesAsync`) can optionally
+//! intersect against the same curated whitelist CLI mode's `SteamworksLocalBackend` always uses,
+//! matching CLI mode's scope (games + family-shared only). `games_only` defaults to `true` - some
+//! users specifically want the unfiltered DLC/soundtracks/videos/tools scope instead, so it's an
+//! explicit opt-out, not an opt-in. Family Sharing / borrowed games are included either way -
+//! that's inherent to PICS-resolved ownership, not something this setting affects.
+
+use std::fs;
+use std::path::PathBuf;
+use std::sync::LazyLock;
+
+use serde::{Deserialize, Serialize};
+use tauri::AppHandle;
+use tokio::sync::Mutex;
+
+use crate::error::{AppError, AppResult};
+use crate::fs_utils::atomic_write_json;
+use crate::platform;
+
+const SETTINGS_FILE_NAME: &str = "ownership_settings.json";
+
+static WRITE_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OwnershipSettings {
+    /// Defaults to `true` (games + family-shared only, matching CLI mode's scope) - an existing
+    /// agent-mode account with no saved preference gets the games-only scope on first fetch after
+    /// upgrading, and can opt back into the unfiltered "all content" scope via the setting.
+    pub games_only: bool,
+}
+
+impl Default for OwnershipSettings {
+    fn default() -> Self {
+        Self { games_only: true }
+    }
+}
+
+fn settings_file_path(app_handle: &AppHandle, steam_id: &str) -> AppResult<PathBuf> {
+    Ok(platform::cache_dir(app_handle)?
+        .join(steam_id)
+        .join(SETTINGS_FILE_NAME))
+}
+
+fn read_unlocked(app_handle: &AppHandle, steam_id: &str) -> AppResult<OwnershipSettings> {
+    let path = settings_file_path(app_handle, steam_id)?;
+    if !path.exists() {
+        return Ok(OwnershipSettings::default());
+    }
+
+    let contents =
+        fs::read_to_string(&path).map_err(|e| AppError::OwnershipSettingsIo(e.to_string()))?;
+    if contents.trim().is_empty() {
+        return Ok(OwnershipSettings::default());
+    }
+
+    match serde_json::from_str(&contents) {
+        Ok(settings) => Ok(settings),
+        Err(e) => {
+            // Self-heal to defaults rather than hard-failing every read for this account - see
+            // `achievement_unlocker::settings::read_unlocked`'s matching comment for why.
+            tracing::warn!(
+                steam_id,
+                error = %e,
+                "ownership settings: ownership_settings.json failed to parse, resetting to defaults"
+            );
+            let defaults = OwnershipSettings::default();
+            write_unlocked(app_handle, steam_id, &defaults)?;
+            Ok(defaults)
+        }
+    }
+}
+
+fn write_unlocked(
+    app_handle: &AppHandle,
+    steam_id: &str,
+    settings: &OwnershipSettings,
+) -> AppResult<()> {
+    let path = settings_file_path(app_handle, steam_id)?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| AppError::OwnershipSettingsIo(e.to_string()))?;
+    }
+    atomic_write_json(&path, settings).map_err(|e| AppError::OwnershipSettingsIo(e.to_string()))
+}
+
+pub async fn get(app_handle: &AppHandle, steam_id: &str) -> AppResult<OwnershipSettings> {
+    let _guard = WRITE_LOCK.lock().await;
+    read_unlocked(app_handle, steam_id)
+}
+
+/// Whole-struct replace, not a dot-path merge - same convention as every other typed settings
+/// module (see `achievement_unlocker::settings::set`'s doc comment).
+pub async fn set(
+    app_handle: &AppHandle,
+    steam_id: &str,
+    settings: OwnershipSettings,
+) -> AppResult<OwnershipSettings> {
+    let _guard = WRITE_LOCK.lock().await;
+    write_unlocked(app_handle, steam_id, &settings)?;
+    Ok(settings)
+}

--- a/src/features/account-switcher/components/AccountSwitcher.tsx
+++ b/src/features/account-switcher/components/AccountSwitcher.tsx
@@ -15,6 +15,7 @@ import { useCardFarmingStore } from '@/shared/stores/cardFarmingStore'
 import { useIdlingStore } from '@/shared/stores/idlingStore'
 import { useProModalStore } from '@/shared/stores/proModalStore'
 import { useReauthModalStore } from '@/shared/stores/reauthModalStore'
+import { useSearchStore } from '@/shared/stores/searchStore'
 import { useSessionStore } from '@/shared/stores/sessionStore'
 import { useSteamWarningStore } from '@/shared/stores/steamWarningStore'
 import { useSubscriptionStore } from '@/shared/stores/subscriptionStore'
@@ -247,6 +248,9 @@ export const AccountSwitcher = ({ compact = false }: AccountSwitcherProps) => {
       }
     }
     switchAccount(key)
+    // A query is scoped to the previous account's data (owned games, achievements, cards) - stale
+    // once the active account changes, same reasoning as the page redirect above.
+    useSearchStore.getState().clearAllQueries()
     const displayName = summaries[key]?.personaName || identifierFor(target)
     logFrontendInfo('accountSwitcher', 'switched active account', { mode: target.mode })
     toast.info(t('dashboard.sidebar.accountSwitcher.switched', { name: displayName }))
@@ -259,6 +263,11 @@ export const AccountSwitcher = ({ compact = false }: AccountSwitcherProps) => {
     const { accountsRemaining, cleanupFailed } = await signOutAccount(key)
     if (cleanupFailed) {
       toast.danger(t('dashboard.sidebar.signOut.error'))
+    }
+    if (wasActive) {
+      // Signing out the active account changes (or clears) which account's data is on screen, so
+      // any in-flight query is stale the same way handleSwitch's is - see clearAllQueries there.
+      useSearchStore.getState().clearAllQueries()
     }
     if (accountsRemaining === 0) {
       router.replace('/')

--- a/src/features/games-list/hooks/useGamesListSync.ts
+++ b/src/features/games-list/hooks/useGamesListSync.ts
@@ -29,10 +29,24 @@ const STALE_AFTER_MS = 5 * 60 * 1000
 // current one's denormalized view (it still lands in `entries[key]` either way). Exported (not
 // just used internally by `useGamesListSync`) so `useGamesList` can drive the same manual-refresh
 // button behavior both `GamesPage` and `IdlingPage` already had.
-export async function fetchGamesList(account: SignedInAccount) {
+//
+// `showLoadingState` drives `phase` back to `'loading'` for the duration of the fetch - both
+// consuming pages already key their full skeleton off `phase === 'loading'` (see
+// `GamesPage.tsx`/`IdlingPage.tsx`), so this is what a caller outside either page (e.g.
+// `useAgentOwnershipSettings`'s scope toggle) uses to make an otherwise-silent refetch visibly
+// obvious, without needing its own local "manual refreshing" state the way each page's own refresh
+// button does.
+export async function fetchGamesList(
+  account: SignedInAccount,
+  options?: { showLoadingState?: boolean },
+) {
   const key = getAccountKey(account)
   const { updateEntry } = useGamesListStore.getState()
-  updateEntry(key, { isRefreshing: true, errorCode: null })
+  updateEntry(key, {
+    isRefreshing: true,
+    errorCode: null,
+    ...(options?.showLoadingState ? { phase: 'loading' } : {}),
+  })
 
   try {
     const fresh = await invoke<OwnedGamesResult>('get_owned_games', { account })

--- a/src/features/settings/components/DebugSettingsTab.tsx
+++ b/src/features/settings/components/DebugSettingsTab.tsx
@@ -6,13 +6,14 @@ import { useSessionStore } from '@/shared/stores/sessionStore'
 
 interface DebugSettingsTabProps {
   // Re-fetch callbacks from SettingsModal's own General/Achievement Unlocker/Inventory Manager/
-  // Card Farming hook instances - see useDebugSettings.ts's doc comment for why `resetSettings`
-  // needs these rather than fetching its own independent copies.
+  // Card Farming/Ownership hook instances - see useDebugSettings.ts's doc comment for why
+  // `resetSettings` needs these rather than fetching its own independent copies.
   refreshGeneralSettings: () => void
   refreshAchievementUnlockerSettings: () => void
   refreshInventorySettings: () => void
   refreshCardFarmingSettings: () => void
   refreshFreeGamesSettings: () => void
+  refreshOwnershipSettings: () => void
 }
 
 // The Debug tab of the (app-wide) SettingsModal - see useDebugSettings.ts's doc comment for the
@@ -26,6 +27,7 @@ export const DebugSettingsTab = ({
   refreshInventorySettings,
   refreshCardFarmingSettings,
   refreshFreeGamesSettings,
+  refreshOwnershipSettings,
 }: DebugSettingsTabProps) => {
   const { t } = useTranslation()
   const account = useSessionStore(state => state.account)
@@ -57,6 +59,7 @@ export const DebugSettingsTab = ({
     refreshInventorySettings,
     refreshCardFarmingSettings,
     refreshFreeGamesSettings,
+    refreshOwnershipSettings,
   })
 
   // Raw tracing lines have no id of their own, and can legitimately repeat (e.g. the same warning

--- a/src/features/settings/components/GeneralSettingsTab.tsx
+++ b/src/features/settings/components/GeneralSettingsTab.tsx
@@ -1,5 +1,5 @@
 import type { TranslationKey } from '@/i18n'
-import type { PersonaState } from '../types'
+import type { OwnershipSettings, PersonaState } from '../types'
 import { disable, enable, isEnabled } from '@tauri-apps/plugin-autostart'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -14,6 +14,7 @@ import {
   Input,
   ListBox,
   Select,
+  Skeleton,
   TextField,
   toast,
   Typography,
@@ -70,6 +71,15 @@ interface GeneralSettingsTabProps {
   onSaveStartMinimized: (enabled: boolean) => Promise<boolean>
   onSaveCloseToTray: (enabled: boolean) => Promise<boolean>
   onSaveAutoUpdateGamesList: (enabled: boolean) => Promise<boolean>
+  // Lifted to `SettingsModal` (unlike `presence`, which stays self-contained below) so
+  // `useDebugSettings`'s "Reset Settings" can refresh this tab's displayed value the same way it
+  // already does for achievement-unlocker/inventory-manager/card-farming/free-games - see
+  // `useAgentOwnershipSettings.ts`'s doc comment.
+  ownershipSettings: OwnershipSettings | null
+  ownershipIsLoading: boolean
+  ownershipIsSaving: boolean
+  ownershipActionErrorCode: string | null
+  onSaveOwnership: (settings: OwnershipSettings) => Promise<boolean>
 }
 
 export const GeneralSettingsTab = ({
@@ -86,6 +96,11 @@ export const GeneralSettingsTab = ({
   onSaveStartMinimized,
   onSaveCloseToTray,
   onSaveAutoUpdateGamesList,
+  ownershipSettings,
+  ownershipIsLoading,
+  ownershipIsSaving,
+  ownershipActionErrorCode,
+  onSaveOwnership,
 }: GeneralSettingsTabProps) => {
   const { t } = useTranslation()
   const [keyValue, setKeyValue] = useState('')
@@ -204,6 +219,15 @@ export const GeneralSettingsTab = ({
     await onSaveCloseToTray(next)
     if (actionErrorCode) {
       toast.danger(t(errorMessageKey(actionErrorCode), { code: actionErrorCode }))
+    }
+  }
+
+  // Instant-apply, matching antiAway/autoUpdateGamesList - `onSaveOwnership` already re-fetches the
+  // games list itself once the setting's saved, so no extra logic is needed here.
+  const handleToggleGamesOnly = async (next: boolean) => {
+    const ok = await onSaveOwnership({ gamesOnly: next })
+    if (!ok && ownershipActionErrorCode) {
+      toast.danger(t(errorMessageKey(ownershipActionErrorCode), { code: ownershipActionErrorCode }))
     }
   }
 
@@ -478,6 +502,25 @@ export const GeneralSettingsTab = ({
                 </Button>
               </div>
             </div>
+          </SettingsRow>
+
+          <SettingsRow
+            description={t('dashboard.settings.general.gamesOnly.description')}
+            title={t('dashboard.settings.general.gamesOnly.label')}
+          >
+            {/* No fallback-guessed `isSelected` while loading - the real default is `true`, but a
+                user who's saved `false` would otherwise flash as "enabled" for a moment on every
+                tab open before flipping to their actual saved value. A skeleton avoids ever
+                showing a wrong state, matching FreeGamesSettingsTab's identical loading gate. */}
+            {ownershipIsLoading || !ownershipSettings ? (
+              <Skeleton className='h-8 w-24 rounded-lg' />
+            ) : (
+              <ToggleSwitch
+                isSelected={ownershipSettings.gamesOnly}
+                isDisabled={ownershipIsSaving}
+                onChange={handleToggleGamesOnly}
+              />
+            )}
           </SettingsRow>
         </>
       )}

--- a/src/features/settings/components/SettingsModal.tsx
+++ b/src/features/settings/components/SettingsModal.tsx
@@ -5,6 +5,7 @@ import { getVersion } from '@tauri-apps/api/app'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { TbChevronRight } from 'react-icons/tb'
+import { useAgentOwnershipSettings } from '../hooks/useAgentOwnershipSettings'
 import { useSettingsModal } from '../hooks/useSettingsModal'
 import { useSteamCredentialsSettings } from '../hooks/useSteamCredentialsSettings'
 import { CustomizationSettingsTab } from './CustomizationSettingsTab'
@@ -137,6 +138,7 @@ export const SettingsModal = () => {
   const cardFarming = useCardFarmingSettings()
   const steamCredentials = useSteamCredentialsSettings()
   const freeGames = useFreeGamesSettings()
+  const ownership = useAgentOwnershipSettings()
   const [appVersion, setAppVersion] = useState<string | null>(null)
 
   // Structural parity with `main`'s sidebar footer (a version string below the tab list).
@@ -216,7 +218,12 @@ export const SettingsModal = () => {
                     onSaveAntiAway={saveAntiAway}
                     onSaveAutoUpdateGamesList={saveAutoUpdateGamesList}
                     onSaveCloseToTray={saveCloseToTray}
+                    onSaveOwnership={ownership.save}
                     onSaveStartMinimized={saveStartMinimized}
+                    ownershipActionErrorCode={ownership.actionErrorCode}
+                    ownershipIsLoading={ownership.isLoading}
+                    ownershipIsSaving={ownership.isSaving}
+                    ownershipSettings={ownership.settings}
                   />
                 </SettingsPanel>
 
@@ -332,6 +339,7 @@ export const SettingsModal = () => {
                     refreshFreeGamesSettings={freeGames.refresh}
                     refreshGeneralSettings={refresh}
                     refreshInventorySettings={inventoryManager.refresh}
+                    refreshOwnershipSettings={ownership.refresh}
                   />
                 </SettingsPanel>
               </TabsRoot>

--- a/src/features/settings/hooks/useAgentOwnershipSettings.ts
+++ b/src/features/settings/hooks/useAgentOwnershipSettings.ts
@@ -1,0 +1,78 @@
+import type { OwnershipSettings } from '../types'
+import { useCallback, useState } from 'react'
+import { useTabGatedLoad } from './useTabGatedLoad'
+import { fetchGamesList } from '@/features/games-list/hooks/useGamesListSync'
+import { useSessionStore } from '@/shared/stores/sessionStore'
+import { useSettingsModalStore } from '@/shared/stores/settingsModalStore'
+import { logFrontendInfo } from '@/shared/utils/frontendLogging'
+import { invoke } from '@/shared/utils/invoke'
+
+export const useAgentOwnershipSettings = () => {
+  const isOpen = useSettingsModalStore(state => state.isOpen)
+  const activeTab = useSettingsModalStore(state => state.activeTab)
+  const account = useSessionStore(state => state.account)
+  const username = account?.mode === 'agent' ? account.username : null
+  const [settings, setSettings] = useState<OwnershipSettings | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const [loadErrorCode, setLoadErrorCode] = useState<string | null>(null)
+  const [actionErrorCode, setActionErrorCode] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    if (!username) return
+    setIsLoading(true)
+    setLoadErrorCode(null)
+    try {
+      setSettings(await invoke<OwnershipSettings>('agent_get_ownership_settings', { username }))
+    } catch (error) {
+      console.error('Error in (agent_get_ownership_settings):', error)
+      setLoadErrorCode(String(error))
+    } finally {
+      setIsLoading(false)
+    }
+  }, [username])
+
+  useTabGatedLoad(isOpen && activeTab === 'general' && !!username, username, load)
+
+  // Toggling this setting changes what `get_owned_games` returns, so it re-fetches the games list
+  // immediately once the save resolves - the user shouldn't have to wait for the next natural
+  // refresh to see the new scope take effect.
+  const save = useCallback(
+    async (next: OwnershipSettings) => {
+      if (!username || !account) return false
+      setIsSaving(true)
+      setActionErrorCode(null)
+      try {
+        setSettings(
+          await invoke<OwnershipSettings>('agent_set_ownership_settings', {
+            username,
+            settings: next,
+          }),
+        )
+        logFrontendInfo('useAgentOwnershipSettings', 'ownership settings saved', {
+          gamesOnly: next.gamesOnly,
+        })
+        fetchGamesList(account, { showLoadingState: true })
+        return true
+      } catch (error) {
+        console.error('Error in (agent_set_ownership_settings):', error)
+        setActionErrorCode(String(error))
+        return false
+      } finally {
+        setIsSaving(false)
+      }
+    },
+    [username, account],
+  )
+
+  return {
+    isAgentAccount: username !== null,
+    settings,
+    isLoading,
+    isSaving,
+    loadErrorCode,
+    actionErrorCode,
+    refresh: load,
+    save,
+  }
+}

--- a/src/features/settings/hooks/useDebugSettings.ts
+++ b/src/features/settings/hooks/useDebugSettings.ts
@@ -11,6 +11,7 @@ import { useTranslation } from 'react-i18next'
 import { debugErrorMessageKey, errorMessageKey } from '../utils/errorMessageKey'
 import { toast } from '@heroui/react'
 import { useRouter } from 'next/router'
+import { fetchGamesList } from '@/features/games-list/hooks/useGamesListSync'
 import { signOutAccount } from '@/shared/hooks/signOutAccount'
 import { useAntiAwayStore } from '@/shared/stores/antiAwayStore'
 import { useAutoUpdateGamesListStore } from '@/shared/stores/autoUpdateGamesListStore'
@@ -67,6 +68,7 @@ interface UseDebugSettingsArgs {
   refreshInventorySettings: () => void
   refreshCardFarmingSettings: () => void
   refreshFreeGamesSettings: () => void
+  refreshOwnershipSettings: () => void
 }
 
 // Backs the Debug tab: a live-polling log viewer, reveal-in-Explorer for the log/settings files, a
@@ -81,6 +83,7 @@ export function useDebugSettings({
   refreshInventorySettings,
   refreshCardFarmingSettings,
   refreshFreeGamesSettings,
+  refreshOwnershipSettings,
 }: UseDebugSettingsArgs) {
   const { t } = useTranslation()
   const router = useRouter()
@@ -230,6 +233,14 @@ export function useDebugSettings({
         refreshCardFarmingSettings()
         refreshFreeGamesSettings()
       }
+      if (account?.mode === 'agent') {
+        // Ownership settings reset back to its default (games-only) alongside every other
+        // per-account setting above - unlike those, a changed scope also changes what
+        // `get_owned_games` itself returns, so the games list needs an explicit refetch, not just
+        // this modal's own displayed value refreshing.
+        refreshOwnershipSettings()
+        fetchGamesList(account, { showLoadingState: true })
+      }
 
       // `refreshGeneralSettings()` only updates this modal's own local snapshot - every denormalized
       // live-sync store (theme/font/tooltips/carousels/background/anti-away/auto-update-games-list)
@@ -266,6 +277,7 @@ export function useDebugSettings({
     refreshInventorySettings,
     refreshCardFarmingSettings,
     refreshFreeGamesSettings,
+    refreshOwnershipSettings,
     t,
   ])
 

--- a/src/features/settings/types.ts
+++ b/src/features/settings/types.ts
@@ -33,6 +33,7 @@ export interface ResetSettingsResult {
   inventorySettings: InventorySettings | null
   cardFarmingSettings: CardFarmingSettings | null
   freeGamesSettings: FreeGamesSettings | null
+  ownershipSettings: OwnershipSettings | null
 }
 
 // Mirrors src-tauri/src/steam_community/mod.rs::SteamCookies. Each cookie-authenticated feature
@@ -61,4 +62,10 @@ export type PersonaState =
 export interface PresenceSettings {
   personaState: PersonaState
   customIdleStatus: string | null
+}
+
+// Mirrors src-tauri/src/steam_agent/ownership_settings.rs's `OwnershipSettings` (serde
+// `rename_all = "camelCase"`). Agent-mode only - see that module's doc comment.
+export interface OwnershipSettings {
+  gamesOnly: boolean
 }

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -969,6 +969,10 @@
           "description": "Replace the \"Playing [game]\" text your friends see while idling with your own custom message.",
           "placeholder": "e.g. Farming trading cards"
         },
+        "gamesOnly": {
+          "label": "Show games only",
+          "description": "Only show owned games and family-shared games in your library, hiding DLC, soundtracks, videos, and tools. Changing this refreshes your games list."
+        },
         "language": {
           "label": "Language",
           "description": "Choose the app's display language.",

--- a/src/shared/components/dashboard/Sidebar.tsx
+++ b/src/shared/components/dashboard/Sidebar.tsx
@@ -184,9 +184,11 @@ export const Sidebar = () => {
         ))}
       </div>
 
-      <div className='flex shrink-0 items-center justify-center overflow-hidden px-2 mb-2'>
-        <AdSlot />
-      </div>
+      {process.env.NODE_ENV === 'production' && (
+        <div className='flex shrink-0 items-center justify-center overflow-hidden px-2 mb-2'>
+          <AdSlot />
+        </div>
+      )}
 
       <div className='shrink-0 border-t border-border p-2'>
         {/* Tier indicator - clickable for `casual` only (the one tier with somewhere left to

--- a/src/shared/stores/searchStore.ts
+++ b/src/shared/stores/searchStore.ts
@@ -32,6 +32,10 @@ interface SearchStore {
   queries: Partial<Record<SearchScopeId, string>>
   setQuery: (scope: SearchScopeId, value: string) => void
   clearQuery: (scope: SearchScopeId) => void
+  // Every query is scoped to the active Steam account's data (owned games, achievements, cards),
+  // so a leftover query from the previous account is stale/meaningless once the active account
+  // changes - see AccountSwitcher's handleSwitch/performSignOut, the only two callers.
+  clearAllQueries: () => void
   // Doubles as the global search modal's open flag (null = closed) - one field instead of two that
   // must stay in sync, same idea `settingsModalStore`'s `isOpen`/`activeTab` pair already uses.
   activeScope: SearchScopeId | null
@@ -55,6 +59,7 @@ export const useSearchStore = create<SearchStore>((set, get) => ({
   queries: {},
   setQuery: (scope, value) => set(state => ({ queries: { ...state.queries, [scope]: value } })),
   clearQuery: scope => set(state => ({ queries: { ...state.queries, [scope]: '' } })),
+  clearAllQueries: () => set({ queries: {} }),
   activeScope: null,
   open: scope => set({ activeScope: scope }),
   close: () => set({ activeScope: null }),


### PR DESCRIPTION
### Description
<!-- Briefly describe the changes in this PR -->

### Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->