### PR TITLE
libs(steam-utility): switch to multi-file trimmed publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,9 +167,15 @@ jobs:
         # $ErrorActionPreference/$LASTEXITCODE check: a pwsh step's pass/fail is the wrapping
         # pwsh.exe exit code, NOT $LASTEXITCODE - a failing dotnet publish would otherwise report
         # this step green and silently carry a stale/missing SteamUtility.exe into the release.
+        # PublishSingleFile=false (deliberately, was true) - the bundled single-file exe was
+        # confirmed via side-by-side VirusTotal testing to be what SecureAge's engine flags as
+        # malicious (a self-extracting single-file .NET bundle reads as packer-like behavior to its
+        # heuristics); the plain multi-file self-contained output came back clean across several
+        # test configurations. SteamUtility.csproj's RemoveDiagnosticOnlyPublishFiles target prunes
+        # the resulting loose-file output back down close to the old single-file size.
         run: |
           $ErrorActionPreference = 'Stop'
-          dotnet publish .\libs\SteamUtility\SteamUtility.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=true -p:DebugType=none -o .\src-tauri\libs\
+          dotnet publish .\libs\SteamUtility\SteamUtility.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=false -p:PublishTrimmed=true -p:DebugType=none -o .\src-tauri\libs\
           if ($LASTEXITCODE -ne 0) { throw "dotnet publish failed with exit code $LASTEXITCODE" }
         shell: pwsh
 

--- a/libs/SteamUtility/SteamUtility.csproj
+++ b/libs/SteamUtility/SteamUtility.csproj
@@ -21,7 +21,17 @@
          SDK-style csproj doesn't use. -->
     <Version>2.0.0</Version>
     <ApplicationIcon>icon.ico</ApplicationIcon>
-    <OutputPath>..\..\src-tauri\libs\</OutputPath>
+    <!-- Deliberately NOT src-tauri/libs (the dotnet publish -o destination used by release.yml and
+         local publish testing) - dotnet publish runs a plain Build as a dependency first, and that
+         Build step writes its own untrimmed, non-self-contained compile output straight into
+         OutputPath before Publish's trimmed/self-contained output lands. When OutputPath and
+         PublishDir were the same folder, that Build-phase output was never cleaned up (Publish
+         doesn't clean its destination), silently doubling the shipped file count with unneeded
+         untrimmed reference assemblies - only invisible before because the old single-file
+         RemovePublishExtras below happened to nuke everything except 3 named files, accidentally
+         cleaning up this pollution too. Falls back to the SDK default (bin\$(Configuration)\, since
+         Append*ToOutputPath below skips the TFM/RID subfolder nesting) - gitignored via libs/.gitignore.
+         PostBuild below still tracks it correctly since it references $(OutputPath) directly. -->
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <!-- Embeds the native runtime DLLs (coreclr.dll etc.) into the single-file exe too, instead of
@@ -44,12 +54,29 @@
        loose DLL) into PublishDir alongside the bundle - the bundle already embeds all of that, so the
        loose copies are pure duplication (see https://aka.ms/dotnet-single-file). Strip everything but
        the exe itself (and the native steam_api64.dll, which must stay a loose file) so `dotnet publish`
-       alone produces a clean output with no follow-up cleanup step. -->
-  <Target Name="RemovePublishExtras" AfterTargets="Publish">
+       alone produces a clean output with no follow-up cleanup step. Only applies in single-file mode -
+       PublishSingleFile is currently off (see release.yml) specifically to avoid SecureAge's
+       VirusTotal false-positive flag on the bundled single-file exe (confirmed via side-by-side
+       VirusTotal testing across both configurations), but the single-file path is kept working here
+       in case it's ever re-enabled. -->
+  <Target Name="RemovePublishExtras" AfterTargets="Publish" Condition="'$(PublishSingleFile)' == 'true'">
     <ItemGroup>
       <PublishExtras Include="$(PublishDir)*" Exclude="$(PublishDir)$(TargetName).exe;$(PublishDir)steam_api64.dll;$(PublishDir)icon.ico" />
     </ItemGroup>
     <Delete Files="@(PublishExtras)" />
+  </Target>
+
+  <!-- Only applies in multi-file mode: these 6 files are debugger/crash-dump/symbol-reading
+       infrastructure, confirmed dead weight via a startup + agent-mode smoke test - DebugType=none
+       means no .pdb ever ships (nothing for DiaSymReader to read), mscordaccore/mscordbi/createdump
+       only matter if an external debugger attaches or the process hard-crashes natively, and
+       clretwrc only feeds an external ETW profiler (PerfView/dotnet-trace). Trims ~6.5MB with no
+       functional loss. -->
+  <Target Name="RemoveDiagnosticOnlyPublishFiles" AfterTargets="Publish" Condition="'$(PublishSingleFile)' != 'true'">
+    <ItemGroup>
+      <DiagnosticOnlyFiles Include="$(PublishDir)mscordaccore.dll;$(PublishDir)mscordaccore_*.dll;$(PublishDir)mscordbi.dll;$(PublishDir)createdump.exe;$(PublishDir)Microsoft.DiaSymReader.Native.amd64.dll;$(PublishDir)clretwrc.dll" />
+    </ItemGroup>
+    <Delete Files="@(DiagnosticOnlyFiles)" />
   </Target>
 
   <ItemGroup>

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "next build",
     "build:docs": "pnpm --filter steam-game-idler-docs build",
     "build:all": "pnpm build && pnpm build:docs",
-    "build:libs": "dotnet publish ./libs/SteamUtility/SteamUtility.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=true -p:DebugType=none -o ./src-tauri/libs/",
+    "build:libs": "dotnet publish ./libs/SteamUtility/SteamUtility.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=false -p:PublishTrimmed=true -p:DebugType=none -o ./src-tauri/libs/",
     "start": "next start",
     "start:docs": "pnpm --filter steam-game-idler-docs start",
     "lint": "eslint .",
@@ -29,6 +29,7 @@
     "typecheck": "tsc --noEmit",
     "pretd": "node scripts/ensure-libs-built.mjs",
     "td": "tauri dev",
+    "pretb": "node scripts/ensure-libs-built.mjs",
     "tb": "tauri build",
     "dd": "pnpm --filter steam-game-idler-docs dev",
     "main": "git checkout main && git pull && git fetch -p"

--- a/scripts/ensure-libs-built.mjs
+++ b/scripts/ensure-libs-built.mjs
@@ -1,8 +1,8 @@
-// Guards `pnpm td` against the class of bug where SteamUtility.exe silently drifts out of sync
-// with libs/SteamUtility/**/*.cs on a given machine (e.g. C# changes pulled from git but never
-// rebuilt locally) - see the ownership-count discrepancy this was added to fix. Runs as `pretd`
-// (pnpm auto-runs this before `td`), so it's a no-op most launches and only pays the full
-// `dotnet publish` cost when source actually changed.
+// Guards `pnpm td`/`pnpm tb` against the class of bug where SteamUtility.exe silently drifts out
+// of sync with libs/SteamUtility/**/*.cs on a given machine (e.g. C# changes pulled from git but
+// never rebuilt locally) - see the ownership-count discrepancy this was added to fix. Runs as
+// `pretd`/`pretb` (pnpm auto-runs these before `td`/`tb`), so it's a no-op most launches and only
+// pays the full `dotnet publish` cost when source actually changed.
 import { execSync } from 'node:child_process'
 import { existsSync, readdirSync, statSync } from 'node:fs'
 import { join } from 'node:path'


### PR DESCRIPTION
To keep the project as transparent as possible, I felt it was better not to ship SteamUtility as a single bundled executable with everything compressed and embedded inside it. Switching to a plain multi-file self-contained publish means every shipped file, the runtime and every dependency alike, is a separate, individually inspectable file that matches Microsoft's own publicly published .NET binaries, rather than one opaque blob with no visible internal structure.