### PR TITLE
libs(steam-utility): stop dropping delisted owned games

### DIFF
--- a/libs/SteamUtility/Backends/SteamKitRemoteBackend.cs
+++ b/libs/SteamUtility/Backends/SteamKitRemoteBackend.cs
@@ -74,9 +74,9 @@ namespace SteamUtility.Backends
             // PICS-based ownership resolves the account's full owned library itself - it has no
             // concept of "checking a candidate list", unlike the local-client backend's
             // BIsSubscribedApp loop. candidateAppIds is accepted for interface parity but ignored;
-            // gamesOnly: true asks GetOwnedGamesAsync to apply the same whitelist filter
-            // SteamworksLocalBackend's own candidate list uses, so this backend's ownership scope
-            // matches it exactly.
+            // gamesOnly: true asks GetOwnedGamesAsync to keep only PICS common.type == "Game" apps
+            // (see its doc comment), so this backend's ownership scope stays real-games-only here
+            // regardless of the user-facing games_only setting used elsewhere.
             var games = await _ownershipManager.GetOwnedGamesAsync(_bot, gamesOnly: true);
             return games.ToList();
         }

--- a/libs/SteamUtility/Daemon/Bot/OwnershipManager.cs
+++ b/libs/SteamUtility/Daemon/Bot/OwnershipManager.cs
@@ -7,7 +7,6 @@ using SteamKit2.Internal;
 using SteamUtility.Core.Errors;
 using SteamUtility.Core.Logging;
 using SteamUtility.Core.Models;
-using SteamUtility.Core.Services;
 
 namespace SteamUtility.Daemon.Bot
 {
@@ -15,8 +14,6 @@ namespace SteamUtility.Daemon.Bot
     // Steam client needed. Correctly reflects Family Sharing / borrowed games.
     public sealed class OwnershipManager
     {
-        private readonly GameWhitelistProvider _whitelistProvider = new();
-
         // Payment methods that were never an actual money transaction through Steam's checkout -
         // Steam's refund policy has nothing to refund for these regardless of how recently the
         // license was granted, so they're excluded entirely from "recently purchased" tracking
@@ -47,6 +44,23 @@ namespace SteamUtility.Daemon.Bot
             Dictionary<uint, DateTime> LastRefundEligiblePurchaseUtcByAppId
         );
 
+        // PICS's own app classification (common.type - SteamKit2's EAppType as a raw string:
+        // "Game", "DLC", "Demo", "Tool", "Application", "Music", "Video", "Config", etc.) is what
+        // gamesOnly filters on below. Deliberately not GameWhitelistProvider's curated external
+        // list (unlike CLI mode's SteamworksLocalBackend.CheckOwnershipAsync, which has no choice -
+        // Steamworks' IsSubscribedApp only answers yes/no for an app id you already have, so CLI
+        // mode depends on the whitelist as its candidate list, not just a filter). Agent mode
+        // already resolves the real, complete owned-app-id set via PICS with no candidate list
+        // needed, so it isn't bound by that constraint - and a store-delisted-but-still-owned game
+        // (e.g. Rocket League, 252950, delisted 2020) keeps its PICS common.type of "Game" even
+        // after falling out of whatever active-store-listing source the external whitelist is
+        // built from, so classifying from PICS directly (rather than an externally curated list)
+        // catches those correctly.
+        private static readonly HashSet<string> GameAppTypes = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "Game",
+        };
+
         public async Task<IReadOnlyList<OwnedGame>> GetOwnedGamesAsync(SteamBot bot, bool gamesOnly)
         {
             if (!bot.IsLoggedOn)
@@ -57,13 +71,13 @@ namespace SteamUtility.Daemon.Bot
             // By default (gamesOnly: false) this is deliberately unfiltered: every PICS-resolved
             // app id tied to an owned license comes through as-is (games, videos/movies, DLC,
             // tools, demos, soundtracks) - some users specifically want this, including non-game
-            // owned content (e.g. Steam movies like 518440/518450) that the whitelist would drop.
-            // When gamesOnly is true (a user-facing setting - see
-            // src-tauri/src/steam_agent/ownership_settings.rs), the resolved app ids are
-            // intersected against the same curated GameWhitelistProvider candidate list CLI mode's
-            // SteamworksLocalBackend.CheckOwnershipAsync always uses, matching CLI mode's scope
-            // exactly. Family Sharing / borrowed games are unaffected either way - that's inherent
-            // to bot.OwnedLicenses below, not something either mode filters.
+            // owned content (e.g. Steam movies like 518440/518450) that gamesOnly would drop. When
+            // gamesOnly is true (a user-facing setting - see
+            // src-tauri/src/steam_agent/ownership_settings.rs), each resolved app id's own PICS
+            // common.type (see GameAppTypes above) decides whether it's kept - applied per-app
+            // below, once PICSGetProductInfo's response is in hand, since type isn't known until
+            // then. Family Sharing / borrowed games are unaffected either way - that's inherent to
+            // bot.OwnedLicenses below, not something either mode filters.
 
             // LicenseListCallback (what OwnedLicenses below is built from) is a separate server
             // push with no ordering guarantee relative to the login success this call is triggered
@@ -74,11 +88,6 @@ namespace SteamUtility.Daemon.Bot
             var resolution = await ResolveOwnedAppIdsAsync(bot);
 
             var appIds = resolution.AppIds;
-            if (gamesOnly)
-            {
-                var whitelist = await _whitelistProvider.GetWhitelistAsync();
-                appIds = new HashSet<uint>(appIds.Where(whitelist.Contains));
-            }
 
             var games = new List<OwnedGame>();
             if (appIds.Count > 0)
@@ -98,6 +107,11 @@ namespace SteamUtility.Daemon.Bot
                 {
                     foreach (var (appId, info) in result.Apps)
                     {
+                        if (gamesOnly && !GameAppTypes.Contains(info.KeyValues["common"]["type"].AsString() ?? ""))
+                        {
+                            continue;
+                        }
+
                         var rawName = info.KeyValues["common"]["name"].AsString();
                         var name = string.IsNullOrEmpty(rawName) ? null : rawName;
                         playtimes.TryGetValue(appId, out var playtime);

--- a/src-tauri/src/steam_agent/manager.rs
+++ b/src-tauri/src/steam_agent/manager.rs
@@ -410,10 +410,10 @@ impl AgentManager {
     /// `Daemon/Bot/OwnershipManager.cs`). No playtime here - that's `games::web_api`'s job, the
     /// same Steam Web API enrichment step CLI mode's ownership check also funnels through.
     ///
-    /// `games_only` mirrors CLI mode's scope (games + family-shared, no DLC/soundtracks/videos/
-    /// tools) by asking the daemon to intersect against the same curated whitelist
-    /// `SteamworksLocalBackend` uses - see `steam_agent::ownership_settings` (defaults to `true`;
-    /// `false` opts into the unfiltered "all content" scope some users specifically want).
+    /// `games_only` asks the daemon to keep only apps whose PICS `common.type` is `"Game"` (games
+    /// + family-shared, no DLC/soundtracks/videos/tools) - not CLI mode's curated whitelist, which
+    /// agent mode doesn't depend on for this; see `steam_agent::ownership_settings` (defaults to
+    /// `true`; `false` opts into the unfiltered "all content" scope some users specifically want).
     ///
     /// Uses `OWNED_APPS_REQUEST_TIMEOUT` rather than the default `send_request` timeout - unlike
     /// every other command sent through this manager, PICS-based ownership resolution scales with

--- a/src-tauri/src/steam_agent/ownership_settings.rs
+++ b/src-tauri/src/steam_agent/ownership_settings.rs
@@ -1,14 +1,20 @@
 //! Per-account owned-games scope setting - agent-mode only, no CLI-mode equivalent (CLI mode
-//! always uses the curated whitelist as its ownership-check candidate list, see
-//! `local_steam::ownership`). Steam-id-scoped file, mirroring `presence_settings`'s pattern
-//! (typed whole-struct get/set, self-healing on a corrupt/unreadable file).
+//! always uses the curated `GameWhitelistProvider` list as its ownership-check candidate list,
+//! see `local_steam::ownership` - a hard technical requirement there, since Steamworks'
+//! `IsSubscribedApp` can only answer yes/no for an app id you already have, unlike PICS). Steam-
+//! id-scoped file, mirroring `presence_settings`'s pattern (typed whole-struct get/set,
+//! self-healing on a corrupt/unreadable file).
 //!
-//! Agent mode's own ownership check (`OwnershipManager.GetOwnedGamesAsync`) can optionally
-//! intersect against the same curated whitelist CLI mode's `SteamworksLocalBackend` always uses,
-//! matching CLI mode's scope (games + family-shared only). `games_only` defaults to `true` - some
-//! users specifically want the unfiltered DLC/soundtracks/videos/tools scope instead, so it's an
-//! explicit opt-out, not an opt-in. Family Sharing / borrowed games are included either way -
-//! that's inherent to PICS-resolved ownership, not something this setting affects.
+//! Agent mode's own ownership check (`OwnershipManager.GetOwnedGamesAsync`) already resolves the
+//! account's real, complete owned-app-id set via PICS with no candidate list needed, so unlike
+//! CLI mode it isn't bound to the curated whitelist at all. `games_only` instead filters per-app
+//! on PICS's own `common.type == "Game"` classification, which stays accurate even for apps
+//! delisted from the store after purchase (e.g. Rocket League, 252950) - a case the curated
+//! whitelist used to silently drop, since it's sourced from active store listings. `games_only`
+//! defaults to `true` - some users specifically want the unfiltered DLC/soundtracks/videos/tools
+//! scope instead, so it's an explicit opt-out, not an opt-in. Family Sharing / borrowed games are
+//! included either way - that's inherent to PICS-resolved ownership, not something this setting
+//! affects.
 
 use std::fs;
 use std::path::PathBuf;


### PR DESCRIPTION
### Description
<!-- Briefly describe the changes in this PR -->

### Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->