### PR TITLE
fix(linux): appimage keyboard input and focus after relaunch

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -45,9 +45,14 @@ fn main() {
                     std::env::set_var("WEBKIT_FORCE_SANDBOX", "0");
                 }
             }
-            // Host GTK input-method modules can link against a different GLib/GTK than what's
-            // bundled inside the AppImage, causing load failures - restrict to the builtin module.
-            if std::env::var_os("GTK_IM_MODULE").is_none() {
+            // Force the builtin input method when GTK_IM_MODULE is unset or set only to xim.
+            // A plain Xfce/X11 session can export xim with no ibus/fcitx running, which broke keyboard input entirely.
+            let im_module = std::env::var_os("GTK_IM_MODULE");
+            let should_override_im_module = match im_module.as_deref().and_then(|v| v.to_str()) {
+                None => true,
+                Some(value) => value.split(':').all(|m| m == "xim"),
+            };
+            if should_override_im_module {
                 unsafe {
                     std::env::set_var("GTK_IM_MODULE", "gtk-im-context-simple");
                 }

--- a/src/features/inventory-manager/components/InventoryManagerPage.tsx
+++ b/src/features/inventory-manager/components/InventoryManagerPage.tsx
@@ -1,4 +1,4 @@
-import type { InventoryItem } from '../types'
+import type { InventoryItem, PriceData } from '../types'
 import type { FilterKey } from './InventoryFilterPanel'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -347,6 +347,8 @@ export const InventoryManagerPage = () => {
       if (!settings) return
       const pairs: [string, string][] = []
       const listedIds: string[] = []
+      // Cache price per item name so duplicate copies reuse one fetch instead of one each.
+      const priceCache = new Map<string, PriceData | undefined>()
       for (const item of candidates) {
         if (isLocked(item.assetid)) continue
         const customPrice = priceDrafts[item.assetid]
@@ -357,19 +359,26 @@ export const InventoryManagerPage = () => {
           listedIds.push(item.assetid)
           continue
         }
-        let priceData = item.priceData
-        if (!priceData) {
-          try {
-            priceData = (await fetchItemPrice(item, { silent: true })) ?? undefined
-          } catch (error) {
-            // Mirrors `main`'s sellCardsList: stop the whole batch the moment price-fetching hits
-            // Steam's rate limit instead of hammering it again for every remaining candidate.
-            if (String(error) === 'market_price_rate_limited') {
-              toast.warning(t('dashboard.inventoryManager.errors.priceRateLimited'))
-              break
+        let priceData: PriceData | undefined
+        if (priceCache.has(item.marketHashName)) {
+          priceData = priceCache.get(item.marketHashName)
+        } else {
+          priceData = item.priceData
+          if (!priceData) {
+            try {
+              priceData = (await fetchItemPrice(item, { silent: true })) ?? undefined
+            } catch (error) {
+              // Mirrors `main`'s sellCardsList: stop the whole batch the moment price-fetching hits
+              // Steam's rate limit instead of hammering it again for every remaining candidate.
+              if (String(error) === 'market_price_rate_limited') {
+                toast.warning(t('dashboard.inventoryManager.errors.priceRateLimited'))
+                break
+              }
+              priceCache.set(item.marketHashName, undefined)
+              continue
             }
-            continue
           }
+          priceCache.set(item.marketHashName, priceData)
         }
         if (!priceData) continue
         const base =

--- a/src/shared/components/pro/GoPro.tsx
+++ b/src/shared/components/pro/GoPro.tsx
@@ -1,3 +1,4 @@
+import { usePlatformStore } from '@/shared/stores/platformStore'
 import { useProModalStore } from '@/shared/stores/proModalStore'
 import { useSubscriptionStore } from '@/shared/stores/subscriptionStore'
 
@@ -11,12 +12,13 @@ import { useSubscriptionStore } from '@/shared/stores/subscriptionStore'
 export const GoPro = () => {
   const subscriptionTier = useSubscriptionStore(state => state.subscriptionTier)
   const openProModal = useProModalStore(state => state.open)
+  const isLinux = usePlatformStore(state => state.currentOs) === 'linux'
 
   if (subscriptionTier !== null) return null
 
   return (
     <button
-      className='shiny-cta mx-2 flex min-w-17! items-center justify-between'
+      className={`shiny-cta mx-2 flex min-w-17! items-center justify-between ${isLinux ? 'force-reduced-motion' : ''}`}
       type='button'
       onClick={() => openProModal()}
     >

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -232,6 +232,17 @@ body {
   opacity: 1;
 }
 
+/* Same reduced motion gating as GoProModal, this animation is expensive under WebKitGTK too. */
+.shiny-cta.force-reduced-motion,
+.shiny-cta.force-reduced-motion::before,
+.shiny-cta.force-reduced-motion::after {
+  animation: none;
+}
+
+.shiny-cta.force-reduced-motion span::before {
+  animation: none;
+}
+
 @keyframes gradient-angle {
   to {
     --gradient-angle: 360deg;


### PR DESCRIPTION
- retry window show/focus on linux after relaunch and second launch attempts, one call isn't reliable
- force GTK_IM_MODULE=simple for appimage builds, xim silently ate all keyboard input including settings
- cache duplicate item prices in sell all/sell dupes so it fetches once per item instead of once per copy