### PR TITLE
refactor(tauri): always mint a sessionid when needed

### DIFF
--- a/docs/changelogs/6.2.3.mdx
+++ b/docs/changelogs/6.2.3.mdx
@@ -12,3 +12,4 @@ tags: ['New', 'Improved']
 ### Improved 🚀
 - Switching languages while signed in with **Steam Sign-in** now automatically refreshes your games list so names update right away
 - Sorting games by title (A-Z / Z-A) now sorts correctly for your selected language instead of always using English alphabetical order
+- Removed the need for users to provide a `sessionid` when enter ing their Steam credentials. SGI will now automatically generate one for you when needed

--- a/src-tauri/src/steam_community/commands.rs
+++ b/src-tauri/src/steam_community/commands.rs
@@ -30,6 +30,12 @@ pub async fn set_steam_credentials(
     cookies: SteamCookies,
 ) -> AppResult<()> {
     let steam_id = resolve_steam_id(&account, &agent_manager).await?;
+    // The frontend no longer collects a `sessionid` from the user (see `session::resolve`'s doc
+    // comment) - never persist whatever placeholder it sent instead of a real one.
+    let cookies = SteamCookies {
+        sid: session::generate_session_id(),
+        ..cookies
+    };
     let result = credentials::set(&steam_id, &cookies);
     if result.is_ok() {
         tracing::info!(steam_id, "steam community: saved pre-validated credentials");
@@ -52,6 +58,12 @@ pub async fn validate_and_save_steam_credentials(
     cookies: SteamCookies,
 ) -> AppResult<SteamCookies> {
     let steam_id = resolve_steam_id(&account, &agent_manager).await?;
+    // Doesn't route through `session::resolve` (see that fn's own doc comment on why manual
+    // cookies get their `sessionid` minted fresh there), so it has to do the same override itself.
+    let cookies = SteamCookies {
+        sid: session::generate_session_id(),
+        ..cookies
+    };
     match session::validate(&steam_id, &cookies).await? {
         SessionStatus::Valid { user } => {
             credentials::set(&steam_id, &cookies)?;

--- a/src-tauri/src/steam_community/session.rs
+++ b/src-tauri/src/steam_community/session.rs
@@ -236,6 +236,15 @@ pub async fn resolve(
     steam_id: &str,
     manual: Option<SteamCookies>,
 ) -> AppResult<SteamCookies> {
+    // `sessionid` is just a CSRF double-submit token - Steam never checks it against anything
+    // server-side beyond "does this match the cookie" (see `generate_session_id`'s doc comment), so
+    // the frontend no longer collects one from the user. Every manually-supplied cookie set gets a
+    // freshly minted one here rather than trusting whatever (if anything) the caller sent.
+    let manual = manual.map(|cookies| SteamCookies {
+        sid: generate_session_id(),
+        ..cookies
+    });
+
     match account {
         GamesAccount::Agent { username } => {
             if let Some(cookies) = manual {

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -32,7 +32,6 @@
       "description": "An unexpected error occurred. Try again, and if it keeps happening, reach out from Help & Support."
     },
     "manualCookies": {
-      "sidLabel": "sessionid",
       "slsLabel": "steamLoginSecure",
       "smaLabel": "steamMachineAuth",
       "smaDescription": "Optional. Only needed if your account has a pending Steam Guard machine confirmation.",

--- a/src/shared/components/ManualCookiesForm.tsx
+++ b/src/shared/components/ManualCookiesForm.tsx
@@ -2,12 +2,11 @@ import { useTranslation } from 'react-i18next'
 import { Description, Input, Label, TextField } from '@heroui/react'
 
 export interface ManualCookiesFormValue {
-  sid: string
   sls: string
   sma: string
 }
 
-export const EMPTY_MANUAL_COOKIES_FORM_VALUE: ManualCookiesFormValue = { sid: '', sls: '', sma: '' }
+export const EMPTY_MANUAL_COOKIES_FORM_VALUE: ManualCookiesFormValue = { sls: '', sma: '' }
 
 interface ManualCookiesFormProps {
   value: ManualCookiesFormValue
@@ -21,20 +20,14 @@ interface ManualCookiesFormProps {
 // `steam_community::SteamCookies` shape every cookie-authenticated feature resolves against).
 // `sma` is optional
 // (`steamMachineAuth{steamId}`, only set for accounts with a pending Steam Guard machine
-// confirmation), `sid`/`sls` are required.
+// confirmation), `sls` is required. No `sessionid` field - it's just a CSRF double-submit token
+// Steam never validates against anything server-side (see `session::resolve`'s Rust-side doc
+// comment), so the app mints one itself instead of asking the user to dig it out of dev tools.
 export const ManualCookiesForm = ({ value, isDisabled, onChange }: ManualCookiesFormProps) => {
   const { t } = useTranslation()
 
   return (
     <div className='flex flex-col gap-4'>
-      <TextField
-        isDisabled={isDisabled}
-        value={value.sid}
-        onChange={sid => onChange({ ...value, sid })}
-      >
-        <Label>{t('common.manualCookies.sidLabel')}</Label>
-        <Input autoComplete='off' placeholder='sessionid' type='password' />
-      </TextField>
       <TextField
         isDisabled={isDisabled}
         value={value.sls}

--- a/src/shared/components/SteamCookiesConnectPanel.tsx
+++ b/src/shared/components/SteamCookiesConnectPanel.tsx
@@ -138,7 +138,7 @@ export function SteamCookiesConnectPanel<T extends SteamCookiesLike>({
   useEffect(() => {
     if (!isLoaded) return
     if (savedCookies && !prefilledFromSaved) {
-      setCookiesForm({ sid: savedCookies.sid, sls: savedCookies.sls, sma: savedCookies.sma ?? '' })
+      setCookiesForm({ sls: savedCookies.sls, sma: savedCookies.sma ?? '' })
       setPrefilledFromSaved(true)
     } else if (!savedCookies && prefilledFromSaved) {
       setCookiesForm(EMPTY_MANUAL_COOKIES_FORM_VALUE)
@@ -146,7 +146,7 @@ export function SteamCookiesConnectPanel<T extends SteamCookiesLike>({
     }
   }, [isLoaded, savedCookies, prefilledFromSaved])
 
-  const canSubmitManual = cookiesForm.sid.trim() !== '' && cookiesForm.sls.trim() !== ''
+  const canSubmitManual = cookiesForm.sls.trim() !== ''
   const canSubmit = method === 'automatic' || canSubmitManual
   const submitLabel = method === 'automatic' ? t('common.actions.signIn') : t('common.actions.save')
 
@@ -168,7 +168,9 @@ export function SteamCookiesConnectPanel<T extends SteamCookiesLike>({
       return
     }
     const manualCookies = {
-      sid: cookiesForm.sid.trim(),
+      // The backend mints its own `sessionid` for every manually-supplied cookie set (see
+      // `session::resolve`'s Rust-side doc comment) - this placeholder is never actually used.
+      sid: '',
       sls: cookiesForm.sls.trim(),
       sma: cookiesForm.sma.trim() || undefined,
     } as T


### PR DESCRIPTION
### Description
<!-- Briefly describe the changes in this PR -->

### Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->