### PR TITLE
docs: spell out default mode steps instead of cross-referencing

### DIFF
--- a/docs/app/(marketing)/docs/_content/features/achievement-unlocker/custom-order-and-unlock-delay.mdx
+++ b/docs/app/(marketing)/docs/_content/features/achievement-unlocker/custom-order-and-unlock-delay.mdx
@@ -18,7 +18,11 @@ You can customize the order, set delays, or both. Each step is optional.
 
 <Steps>
   <Step>
-    Follow steps 1 and 2 from the [Default Mode](/docs/features/achievement-unlocker#default-mode) section
+    Click <MockButton type='achievement-unlocker' /> in the sidebar
+  </Step>
+
+  <Step>
+    Go to the <MockButton type='all-games' /> tab and click the <MockButton type='context-add' /> button on individual games to add them to your queue
   </Step>
 
   <Step>

--- a/docs/app/(marketing)/docs/_content/features/achievement-unlocker/import-timings.mdx
+++ b/docs/app/(marketing)/docs/_content/features/achievement-unlocker/import-timings.mdx
@@ -16,7 +16,11 @@ The Import Timings feature lets you copy the unlock order and achievement delays
 
 <Steps>
   <Step>
-    Follow steps 1 and 2 from the [Default Mode](/docs/features/achievement-unlocker#default-mode) section
+    Click <MockButton type='achievement-unlocker' /> in the sidebar
+  </Step>
+
+  <Step>
+    Go to the <MockButton type='all-games' /> tab and click the <MockButton type='context-add' /> button on individual games to add them to your queue
   </Step>
 
   <Step>

--- a/src/features/ai-chat/components/AiChatOverlay.tsx
+++ b/src/features/ai-chat/components/AiChatOverlay.tsx
@@ -58,7 +58,7 @@ const markdownComponents: Components = {
   ),
   a: ({ children, href }) => (
     <button
-      className='text-left underline underline-offset-2'
+      className='cursor-pointer text-left text-accent underline underline-offset-2 duration-150 hover:text-accent/80'
       type='button'
       onClick={() => href && openExternalLink(href)}
     >


### PR DESCRIPTION
### Description
<!-- Briefly describe the changes in this PR -->

### Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->